### PR TITLE
Particle rework

### DIFF
--- a/src/data/direction_cosine.rs
+++ b/src/data/direction_cosine.rs
@@ -9,18 +9,16 @@ use crate::{
     utils::mc_rng_state::rng_sample,
 };
 
+use super::mc_vector::MCVector;
+
 /// Structure used to model a direction.
 ///
 /// Alpha, beta and gamma are just a normalized (x, y, z) vector, not Euler
 /// angles.
 #[derive(Debug, Clone, Default)]
 pub struct DirectionCosine<T: CustomFloat> {
-    /// Normalized x coordinate.
-    pub alpha: T,
-    /// Normalized y coordinate.
-    pub beta: T,
-    /// Normalized z coordinate.
-    pub gamma: T,
+    /// Normalized `(x, y, z)` direction vector.
+    pub dir: MCVector<T>,
 }
 
 impl<T: CustomFloat> DirectionCosine<T> {
@@ -31,14 +29,14 @@ impl<T: CustomFloat> DirectionCosine<T> {
         let pi: T = FromPrimitive::from_f64(PI).unwrap();
 
         // sample gamma
-        self.gamma = one - two * rng_sample(seed);
-        let sine_gamma = (one - self.gamma * self.gamma).sqrt();
+        self.dir.z = one - two * rng_sample(seed);
+        let sine_gamma = (one - self.dir.z * self.dir.z).sqrt();
 
         // sample phi and set the other angles using it
         let phi = pi * (two * rng_sample(seed) - one);
 
-        self.alpha = sine_gamma * phi.cos();
-        self.beta = sine_gamma * phi.sin();
+        self.dir.x = sine_gamma * phi.cos();
+        self.dir.y = sine_gamma * phi.sin();
     }
 
     /// Rotates a 3D vector that is defined by the angles Theta and Phi
@@ -57,25 +55,25 @@ impl<T: CustomFloat> DirectionCosine<T> {
         let one: T = FromPrimitive::from_f64(1.0).unwrap();
         let threshold: T = FromPrimitive::from_f64(1e-6).unwrap(); // order of TINY_FLOAT.sqrt()
 
-        let cos_theta_zero = self.gamma;
+        let cos_theta_zero = self.dir.z;
         let sin_theta_zero = (one - cos_theta_zero * cos_theta_zero).sqrt();
 
         let (cos_phi_zero, sin_phi_zero): (T, T) = if sin_theta_zero < threshold {
             (one, zero())
         } else {
-            (self.alpha / sin_theta_zero, self.beta / sin_theta_zero)
+            (self.dir.x / sin_theta_zero, self.dir.y / sin_theta_zero)
         };
 
         // compute the rotation
-        self.alpha = cos_theta_zero * cos_phi_zero * (sine_theta * cosine_phi)
+        self.dir.x = cos_theta_zero * cos_phi_zero * (sine_theta * cosine_phi)
             - sin_phi_zero * (sine_theta * sine_phi)
             + sin_theta_zero * cos_phi_zero * cosine_theta;
 
-        self.beta = cos_theta_zero * sin_phi_zero * (sine_theta * cosine_phi)
+        self.dir.y = cos_theta_zero * sin_phi_zero * (sine_theta * cosine_phi)
             + cos_phi_zero * (sine_theta * sine_phi)
             + sin_theta_zero * sin_phi_zero * cosine_theta;
 
-        self.gamma =
+        self.dir.z =
             -sin_theta_zero * (sine_theta * cosine_phi) + zero() + cos_theta_zero * cosine_theta;
     }
 }
@@ -91,30 +89,31 @@ mod tests {
 
     #[test]
     fn sample_isotropic() {
-        let mut dd: DirectionCosine<f64> = DirectionCosine {
-            alpha: 0.2140,
-            beta: 0.8621,
-            gamma: 0.7821,
-        };
+        let mut dd: DirectionCosine<f64> = DirectionCosine::default();
         let mut seed: u64 = 90374384094798327;
         dd.sample_isotropic(&mut seed);
 
-        assert_eq!(dd.alpha, 0.9083218129645693);
-        assert_eq!(dd.beta, -0.3658911896631176);
-        assert_eq!(dd.gamma, 0.2026699815455325);
+        assert_eq!(dd.dir.x, 0.9083218129645693);
+        assert_eq!(dd.dir.y, -0.3658911896631176);
+        assert_eq!(dd.dir.z, 0.2026699815455325);
     }
 
     #[test]
     fn rotate_vector() {
+        let alpha = 0.2140;
+        let beta = 0.8621;
+        let gamma = 0.7821;
         let mut dd: DirectionCosine<f64> = DirectionCosine {
-            alpha: 0.2140,
-            beta: 0.8621,
-            gamma: 0.7821,
+            dir: MCVector {
+                x: alpha,
+                y: beta,
+                z: gamma,
+            },
         };
         dd.rotate_3d_vector(1.0.sin(), 1.0.cos(), 2.0.sin(), 2.0.cos());
 
-        assert_eq!(dd.alpha, -1.0369691350703922);
-        assert_eq!(dd.beta, 0.3496694784021821);
-        assert_eq!(dd.gamma, 0.6407833194623658);
+        assert_eq!(dd.dir.x, -1.0369691350703922);
+        assert_eq!(dd.dir.y, 0.3496694784021821);
+        assert_eq!(dd.dir.z, 0.6407833194623658);
     }
 }

--- a/src/montecarlo.rs
+++ b/src/montecarlo.rs
@@ -89,8 +89,9 @@ impl<T: CustomFloat> MonteCarlo<T> {
             particle_list.iter().for_each(|pp| {
                 // load particle & update energy group
                 let mut particle = MCParticle::new(pp);
-                particle.energy_group =
-                    self.nuclear_data.get_energy_groups(particle.kinetic_energy);
+                particle.energy_group = self
+                    .nuclear_data
+                    .get_energy_groups(particle.base_particle.kinetic_energy);
                 spectrum[particle.energy_group] += 1;
             });
         };

--- a/src/particles/mc_base_particle.rs
+++ b/src/particles/mc_base_particle.rs
@@ -61,22 +61,7 @@ impl<T: CustomFloat> MCBaseParticle<T> {
     /// Constructor from a [MCParticle] object. To construct from a
     /// [MCBaseParticle] object, we derive the [Clone] trait.
     pub fn new(particle: &MCParticle<T>) -> Self {
-        MCBaseParticle {
-            coordinate: particle.coordinate,
-            velocity: particle.velocity,
-            kinetic_energy: particle.kinetic_energy,
-            weight: particle.weight,
-            time_to_census: particle.time_to_census,
-            age: particle.age,
-            num_mean_free_paths: particle.num_mean_free_paths,
-            num_segments: particle.num_segments,
-            random_number_seed: particle.random_number_seed,
-            identifier: particle.identifier,
-            last_event: particle.last_event,
-            species: particle.species,
-            domain: particle.domain,
-            cell: particle.cell,
-        }
+        particle.base_particle.clone()
     }
 
     /// Return the current particle's location.

--- a/src/particles/mc_particle.rs
+++ b/src/particles/mc_particle.rs
@@ -8,58 +8,31 @@ use std::fmt::Display;
 use num::zero;
 
 use crate::{
-    constants::CustomFloat,
-    data::{direction_cosine::DirectionCosine, mc_vector::MCVector, tallies::MCTallyEvent},
+    constants::CustomFloat, data::direction_cosine::DirectionCosine,
     geometry::mc_location::MCLocation,
 };
 
-use super::mc_base_particle::{MCBaseParticle, Species};
+use super::mc_base_particle::MCBaseParticle;
 
 /// Structure used to hold all data of a particle.
 ///
 /// This is mostly used for computations during the tracking section.
 #[derive(Debug, Default, Clone)]
 pub struct MCParticle<T: CustomFloat> {
-    /// Current position of the particle.
-    pub coordinate: MCVector<T>,
-    /// Current velocity of the particle.
-    pub velocity: MCVector<T>,
+    /// Base data of the particle.
+    pub base_particle: MCBaseParticle<T>,
     /// Direction of the particle as a normalized `(x, y, z)` vector.
     pub direction_cosine: DirectionCosine<T>,
-    /// Kinetic energy of the particle.
-    pub kinetic_energy: T,
-    /// Weight of the particle.
-    pub weight: T,
-    /// Time remaining before this particle hit census.
-    pub time_to_census: T,
     /// Cache-ing the current total cross section/
     pub total_cross_section: T,
-    /// Age of the particle.
-    pub age: T,
-    /// Number of mean free paths to a collision.
-    pub num_mean_free_paths: T,
     /// Distance to a collision.
     pub mean_free_path: T,
     /// Distance this particle travels in a segment.
     pub segment_path_length: T,
-    /// Random number seed used by the PRNG call for this particle.
-    pub random_number_seed: u64,
-    /// Unique ID used to identify and track individual particles.
-    pub identifier: u64,
-    /// Last event this particle underwent.
-    pub last_event: MCTallyEvent,
-    /// Number of segments the particle travelled.
-    pub num_segments: T,
     /// Task working on
     pub task: usize,
-    /// Species of the particle.
-    pub species: Species,
     /// Current energy group the particle belong to.
     pub energy_group: usize,
-    /// Current domain in the spatial grid.
-    pub domain: usize,
-    /// Current cell in the current domain.
-    pub cell: usize,
     /// Nearest facet.
     pub facet: usize,
     /// Normal dot product value kept when crossing a facet.
@@ -77,26 +50,13 @@ impl<T: CustomFloat> MCParticle<T> {
         };
 
         MCParticle {
-            coordinate: from_particle.coordinate,
-            velocity: from_particle.velocity,
+            base_particle: from_particle.clone(),
             direction_cosine: d_cos,
-            kinetic_energy: from_particle.kinetic_energy,
-            weight: from_particle.weight,
-            time_to_census: from_particle.time_to_census,
             total_cross_section: zero(),
-            age: from_particle.age,
-            num_mean_free_paths: from_particle.num_mean_free_paths,
             mean_free_path: zero(),
             segment_path_length: zero(),
-            random_number_seed: from_particle.random_number_seed,
-            identifier: from_particle.identifier,
-            last_event: from_particle.last_event,
-            num_segments: from_particle.num_segments,
             task: 0,
-            species: from_particle.species,
             energy_group: 0,
-            domain: from_particle.domain,
-            cell: from_particle.cell,
             facet: 0,
             normal_dot: zero(),
         }
@@ -105,8 +65,8 @@ impl<T: CustomFloat> MCParticle<T> {
     /// Returns the location of the particle as a [MCLocation] object.
     pub fn get_location(&self) -> MCLocation {
         MCLocation {
-            domain: Some(self.domain),
-            cell: Some(self.cell),
+            domain: Some(self.base_particle.domain),
+            cell: Some(self.base_particle.cell),
             facet: Some(self.facet),
         }
     }
@@ -114,9 +74,9 @@ impl<T: CustomFloat> MCParticle<T> {
     /// Update the particle's field to model its movement along the specified
     /// direction and distance
     pub fn move_particle(&mut self, distance: T) {
-        self.coordinate.x += self.direction_cosine.alpha * distance;
-        self.coordinate.y += self.direction_cosine.beta * distance;
-        self.coordinate.z += self.direction_cosine.gamma * distance;
+        self.base_particle.coordinate.x += self.direction_cosine.alpha * distance;
+        self.base_particle.coordinate.y += self.direction_cosine.beta * distance;
+        self.base_particle.coordinate.z += self.direction_cosine.gamma * distance;
     }
 }
 
@@ -126,35 +86,47 @@ impl<T: CustomFloat> Display for MCParticle<T> {
         writeln!(
             f,
             "coordinate: {} {} {}",
-            self.coordinate.x, self.coordinate.y, self.coordinate.z
+            self.base_particle.coordinate.x,
+            self.base_particle.coordinate.y,
+            self.base_particle.coordinate.z
         )?;
         writeln!(
             f,
             "velocity: {} {} {}",
-            self.velocity.x, self.velocity.y, self.velocity.z
+            self.base_particle.velocity.x,
+            self.base_particle.velocity.y,
+            self.base_particle.velocity.z
         )?;
         writeln!(
             f,
             "direction cosine: {} {} {}",
             self.direction_cosine.alpha, self.direction_cosine.beta, self.direction_cosine.gamma
         )?;
-        writeln!(f, "kinetic energy: {}", self.kinetic_energy)?;
-        writeln!(f, "weight: {}", self.weight)?;
-        writeln!(f, "time to census: {}", self.time_to_census)?;
+        writeln!(f, "kinetic energy: {}", self.base_particle.kinetic_energy)?;
+        writeln!(f, "weight: {}", self.base_particle.weight)?;
+        writeln!(f, "time to census: {}", self.base_particle.time_to_census)?;
         writeln!(f, "total cross section: {}", self.total_cross_section)?;
-        writeln!(f, "age: {}", self.age)?;
-        writeln!(f, "num mean free paths: {}", self.num_mean_free_paths)?;
+        writeln!(f, "age: {}", self.base_particle.age)?;
+        writeln!(
+            f,
+            "num mean free paths: {}",
+            self.base_particle.num_mean_free_paths
+        )?;
         writeln!(f, "mean free path: {}", self.mean_free_path)?;
         writeln!(f, "segment path length: {}", self.segment_path_length)?;
-        writeln!(f, "random number seed: {}", self.random_number_seed)?;
-        writeln!(f, "identifier: {}", self.identifier)?;
-        writeln!(f, "last event: {:?}", self.last_event)?;
-        writeln!(f, "num segments: {}", self.num_segments)?;
+        writeln!(
+            f,
+            "random number seed: {}",
+            self.base_particle.random_number_seed
+        )?;
+        writeln!(f, "identifier: {}", self.base_particle.identifier)?;
+        writeln!(f, "last event: {:?}", self.base_particle.last_event)?;
+        writeln!(f, "num segments: {}", self.base_particle.num_segments)?;
         writeln!(f, "task: {}", self.task)?;
-        writeln!(f, "species: {:?}", self.species)?;
+        writeln!(f, "species: {:?}", self.base_particle.species)?;
         writeln!(f, "energy group: {}", self.energy_group)?;
-        writeln!(f, "domain: {}", self.domain)?;
-        writeln!(f, "cell: {}", self.cell)?;
+        writeln!(f, "domain: {}", self.base_particle.domain)?;
+        writeln!(f, "cell: {}", self.base_particle.cell)?;
         writeln!(f, "facet: {}", self.facet)?;
         writeln!(f, "normal dot: {}", self.normal_dot)
     }
@@ -163,6 +135,6 @@ impl<T: CustomFloat> Display for MCParticle<T> {
 impl<T: CustomFloat> PartialEq for MCParticle<T> {
     fn eq(&self, other: &Self) -> bool {
         // is this enough?
-        self.identifier == other.identifier
+        self.base_particle.identifier == other.base_particle.identifier
     }
 }

--- a/src/particles/mc_particle.rs
+++ b/src/particles/mc_particle.rs
@@ -44,9 +44,7 @@ impl<T: CustomFloat> MCParticle<T> {
     pub fn new(from_particle: &MCBaseParticle<T>) -> Self {
         let speed = from_particle.velocity.length();
         let d_cos = DirectionCosine {
-            alpha: speed.recip() * from_particle.velocity.x,
-            beta: speed.recip() * from_particle.velocity.y,
-            gamma: speed.recip() * from_particle.velocity.z,
+            dir: from_particle.velocity * speed.recip(),
         };
 
         MCParticle {
@@ -74,9 +72,7 @@ impl<T: CustomFloat> MCParticle<T> {
     /// Update the particle's field to model its movement along the specified
     /// direction and distance
     pub fn move_particle(&mut self, distance: T) {
-        self.base_particle.coordinate.x += self.direction_cosine.alpha * distance;
-        self.base_particle.coordinate.y += self.direction_cosine.beta * distance;
-        self.base_particle.coordinate.z += self.direction_cosine.gamma * distance;
+        self.base_particle.coordinate += self.direction_cosine.dir * distance;
     }
 }
 
@@ -100,7 +96,7 @@ impl<T: CustomFloat> Display for MCParticle<T> {
         writeln!(
             f,
             "direction cosine: {} {} {}",
-            self.direction_cosine.alpha, self.direction_cosine.beta, self.direction_cosine.gamma
+            self.direction_cosine.dir.x, self.direction_cosine.dir.y, self.direction_cosine.dir.z
         )?;
         writeln!(f, "kinetic energy: {}", self.base_particle.kinetic_energy)?;
         writeln!(f, "weight: {}", self.base_particle.weight)?;

--- a/src/simulation/collision_event.rs
+++ b/src/simulation/collision_event.rs
@@ -40,9 +40,10 @@ fn update_trajectory<T: CustomFloat>(energy: T, angle: T, particle: &mut MCParti
     particle
         .direction_cosine
         .rotate_3d_vector(sin_theta, cos_theta, sin_phi, cos_phi);
-    particle.base_particle.velocity.x = speed * particle.direction_cosine.alpha;
-    particle.base_particle.velocity.y = speed * particle.direction_cosine.beta;
-    particle.base_particle.velocity.z = speed * particle.direction_cosine.gamma;
+    particle.base_particle.velocity = particle.direction_cosine.dir * speed;
+    //particle.base_particle.velocity.x = speed * particle.direction_cosine.alpha;
+    //particle.base_particle.velocity.y = speed * particle.direction_cosine.beta;
+    //particle.base_particle.velocity.z = speed * particle.direction_cosine.gamma;
     rdm_number = rng_sample(&mut particle.base_particle.random_number_seed);
     particle.base_particle.num_mean_free_paths = -one * rdm_number.ln();
 }
@@ -199,9 +200,11 @@ mod tests {
             z: 1.0,
         };
         let d_cos: DirectionCosine<f64> = DirectionCosine {
-            alpha: 1.0 / 3.0.sqrt(),
-            beta: 1.0 / 3.0.sqrt(),
-            gamma: 1.0 / 3.0.sqrt(),
+            dir: MCVector {
+                x: 1.0 / 3.0.sqrt(),
+                y: 1.0 / 3.0.sqrt(),
+                z: 1.0 / 3.0.sqrt(),
+            },
         };
         let e: f64 = 1.0;
         pp.base_particle.velocity = vv;
@@ -214,9 +217,9 @@ mod tests {
         // update & print result
         update_trajectory(energy, angle, &mut pp);
 
-        assert!((pp.direction_cosine.alpha - 0.620283).abs() < 1.0e-6);
-        assert!((pp.direction_cosine.beta - 0.620283).abs() < 1.0e-6);
-        assert!((pp.direction_cosine.gamma - (-0.480102)).abs() < 1.0e-6);
+        assert!((pp.direction_cosine.dir.x - 0.620283).abs() < 1.0e-6);
+        assert!((pp.direction_cosine.dir.y - 0.620283).abs() < 1.0e-6);
+        assert!((pp.direction_cosine.dir.z - (-0.480102)).abs() < 1.0e-6);
         assert!((pp.base_particle.kinetic_energy - energy).abs() < TINY_FLOAT);
     }
 }

--- a/src/simulation/collision_event.rs
+++ b/src/simulation/collision_event.rs
@@ -29,22 +29,22 @@ fn update_trajectory<T: CustomFloat>(energy: T, angle: T, particle: &mut MCParti
     // value for update
     let cos_theta: T = angle;
     let sin_theta: T = (one - cos_theta * cos_theta).sqrt();
-    let mut rdm_number: T = rng_sample(&mut particle.random_number_seed);
+    let mut rdm_number: T = rng_sample(&mut particle.base_particle.random_number_seed);
     let phi = two * pi * rdm_number;
     let sin_phi: T = phi.sin();
     let cos_phi: T = phi.cos();
     let speed: T = c * (one - ((nrm * nrm) / ((energy + nrm) * (energy + nrm)))).sqrt();
 
     // update
-    particle.kinetic_energy = energy;
+    particle.base_particle.kinetic_energy = energy;
     particle
         .direction_cosine
         .rotate_3d_vector(sin_theta, cos_theta, sin_phi, cos_phi);
-    particle.velocity.x = speed * particle.direction_cosine.alpha;
-    particle.velocity.y = speed * particle.direction_cosine.beta;
-    particle.velocity.z = speed * particle.direction_cosine.gamma;
-    rdm_number = rng_sample(&mut particle.random_number_seed);
-    particle.num_mean_free_paths = -one * rdm_number.ln();
+    particle.base_particle.velocity.x = speed * particle.direction_cosine.alpha;
+    particle.base_particle.velocity.y = speed * particle.direction_cosine.beta;
+    particle.base_particle.velocity.z = speed * particle.direction_cosine.gamma;
+    rdm_number = rng_sample(&mut particle.base_particle.random_number_seed);
+    particle.base_particle.num_mean_free_paths = -one * rdm_number.ln();
 }
 
 /// Transforms a given particle according to an internally drawn type of collision.
@@ -63,12 +63,13 @@ pub fn collision_event<T: CustomFloat>(
     tally_idx: usize,
     extra: &mut Vec<MCBaseParticle<T>>,
 ) -> bool {
-    let mat_gidx = mcco.domain[particle.domain].cell_state[particle.cell].material;
+    let mat_gidx =
+        mcco.domain[particle.base_particle.domain].cell_state[particle.base_particle.cell].material;
 
     // ==========================
     // Pick an isotope & reaction
 
-    let rdm_number: T = rng_sample(&mut particle.random_number_seed);
+    let rdm_number: T = rng_sample(&mut particle.base_particle.random_number_seed);
     let total_xsection: T = particle.total_cross_section;
 
     let mut current_xsection: T = total_xsection * rdm_number;
@@ -88,8 +89,8 @@ pub fn collision_event<T: CustomFloat>(
                 current_xsection -= macroscopic_cross_section(
                     mcco,
                     reaction_idx,
-                    particle.domain,
-                    particle.cell,
+                    particle.base_particle.domain,
+                    particle.base_particle.cell,
                     iso_idx,
                     particle.energy_group,
                 );
@@ -117,9 +118,9 @@ pub fn collision_event<T: CustomFloat>(
     let (energy_out, angle_out) = mcco.nuclear_data.isotopes[selected_unique_n][0].reactions
         [selected_react]
         .sample_collision(
-            particle.kinetic_energy,
+            particle.base_particle.kinetic_energy,
             mat_mass,
-            &mut particle.random_number_seed,
+            &mut particle.base_particle.random_number_seed,
         );
     // number of particles resulting from the collision, including the original
     // e.g. zero means the original particle was absorbed or invalidated in some way
@@ -151,8 +152,9 @@ pub fn collision_event<T: CustomFloat>(
     if n_out > 1 {
         for secondary_idx in 1..n_out {
             let mut sec_particle = particle.clone();
-            sec_particle.random_number_seed = spawn_rn_seed::<T>(&mut particle.random_number_seed);
-            sec_particle.identifier = sec_particle.random_number_seed;
+            sec_particle.base_particle.random_number_seed =
+                spawn_rn_seed::<T>(&mut particle.base_particle.random_number_seed);
+            sec_particle.base_particle.identifier = sec_particle.base_particle.random_number_seed;
             update_trajectory(
                 energy_out[secondary_idx],
                 angle_out[secondary_idx],
@@ -163,7 +165,9 @@ pub fn collision_event<T: CustomFloat>(
     }
 
     update_trajectory(energy_out[0], angle_out[0], particle);
-    particle.energy_group = mcco.nuclear_data.get_energy_groups(particle.kinetic_energy);
+    particle.energy_group = mcco
+        .nuclear_data
+        .get_energy_groups(particle.base_particle.kinetic_energy);
 
     if n_out > 1 {
         extra.push(MCBaseParticle::new(particle));
@@ -200,9 +204,9 @@ mod tests {
             gamma: 1.0 / 3.0.sqrt(),
         };
         let e: f64 = 1.0;
-        pp.velocity = vv;
+        pp.base_particle.velocity = vv;
         pp.direction_cosine = d_cos;
-        pp.kinetic_energy = e;
+        pp.base_particle.kinetic_energy = e;
         let mut seed: u64 = 90374384094798327;
         let energy = rng_sample(&mut seed);
         let angle = rng_sample(&mut seed);
@@ -213,6 +217,6 @@ mod tests {
         assert!((pp.direction_cosine.alpha - 0.620283).abs() < 1.0e-6);
         assert!((pp.direction_cosine.beta - 0.620283).abs() < 1.0e-6);
         assert!((pp.direction_cosine.gamma - (-0.480102)).abs() < 1.0e-6);
-        assert!((pp.kinetic_energy - energy).abs() < TINY_FLOAT);
+        assert!((pp.base_particle.kinetic_energy - energy).abs() < TINY_FLOAT);
     }
 }

--- a/src/simulation/collision_event.rs
+++ b/src/simulation/collision_event.rs
@@ -41,9 +41,6 @@ fn update_trajectory<T: CustomFloat>(energy: T, angle: T, particle: &mut MCParti
         .direction_cosine
         .rotate_3d_vector(sin_theta, cos_theta, sin_phi, cos_phi);
     particle.base_particle.velocity = particle.direction_cosine.dir * speed;
-    //particle.base_particle.velocity.x = speed * particle.direction_cosine.alpha;
-    //particle.base_particle.velocity.y = speed * particle.direction_cosine.beta;
-    //particle.base_particle.velocity.z = speed * particle.direction_cosine.gamma;
     rdm_number = rng_sample(&mut particle.base_particle.random_number_seed);
     particle.base_particle.num_mean_free_paths = -one * rdm_number.ln();
 }

--- a/src/simulation/mc_facet_crossing_event.rs
+++ b/src/simulation/mc_facet_crossing_event.rs
@@ -31,26 +31,26 @@ pub fn facet_crossing_event<T: CustomFloat>(
     match facet_adjacency.event {
         MCSubfacetAdjacencyEvent::TransitOnProcessor => {
             // particle enters an adjacent cell
-            particle.domain = facet_adjacency.adjacent.domain.unwrap();
-            particle.cell = facet_adjacency.adjacent.cell.unwrap();
+            particle.base_particle.domain = facet_adjacency.adjacent.domain.unwrap();
+            particle.base_particle.cell = facet_adjacency.adjacent.cell.unwrap();
             particle.facet = facet_adjacency.adjacent.facet.unwrap();
-            particle.last_event = MCTallyEvent::FacetCrossingTransitExit;
+            particle.base_particle.last_event = MCTallyEvent::FacetCrossingTransitExit;
         }
         MCSubfacetAdjacencyEvent::BoundaryEscape => {
             // particle escape the system
-            particle.last_event = MCTallyEvent::FacetCrossingEscape;
+            particle.base_particle.last_event = MCTallyEvent::FacetCrossingEscape;
         }
         MCSubfacetAdjacencyEvent::BoundaryReflection => {
             // particle reflect off a system boundary
-            particle.last_event = MCTallyEvent::FacetCrossingReflection
+            particle.base_particle.last_event = MCTallyEvent::FacetCrossingReflection
         }
         MCSubfacetAdjacencyEvent::TransitOffProcessor => {
             // particle enters an adjacent cell that belongs to
             // a domain managed by another processor.
-            particle.domain = facet_adjacency.adjacent.domain.unwrap();
-            particle.cell = facet_adjacency.adjacent.cell.unwrap();
+            particle.base_particle.domain = facet_adjacency.adjacent.domain.unwrap();
+            particle.base_particle.cell = facet_adjacency.adjacent.cell.unwrap();
             particle.facet = facet_adjacency.adjacent.facet.unwrap();
-            particle.last_event = MCTallyEvent::FacetCrossingCommunication;
+            particle.base_particle.last_event = MCTallyEvent::FacetCrossingCommunication;
 
             let neighbor_rank: usize = mcco.domain[facet_adjacency.current.domain.unwrap()]
                 .mesh
@@ -60,5 +60,5 @@ pub fn facet_crossing_event<T: CustomFloat>(
         }
         MCSubfacetAdjacencyEvent::AdjacencyUndefined => panic!(),
     }
-    particle.last_event
+    particle.base_particle.last_event
 }

--- a/src/simulation/mct.rs
+++ b/src/simulation/mct.rs
@@ -168,10 +168,10 @@ pub fn reflect_particle<T: CustomFloat>(mcco: &MonteCarlo<T>, particle: &mut MCP
         new_d_cos.gamma -= dot * facet_normal.z;
         particle.direction_cosine = new_d_cos;
     }
-    let particle_speed = particle.velocity.length();
-    particle.velocity.x = particle_speed * particle.direction_cosine.alpha;
-    particle.velocity.y = particle_speed * particle.direction_cosine.beta;
-    particle.velocity.z = particle_speed * particle.direction_cosine.gamma;
+    let particle_speed = particle.base_particle.velocity.length();
+    particle.base_particle.velocity.x = particle_speed * particle.direction_cosine.alpha;
+    particle.base_particle.velocity.y = particle_speed * particle.direction_cosine.beta;
+    particle.base_particle.velocity.z = particle_speed * particle.direction_cosine.gamma;
 }
 
 // ==============================
@@ -185,7 +185,7 @@ fn mct_nf_3dg<T: CustomFloat>(
     let huge_f: T = FromPrimitive::from_f64(HUGE_FLOAT).unwrap();
 
     let mut location = particle.get_location();
-    let coords = particle.coordinate;
+    let coords = particle.base_particle.coordinate;
     let direction_cosine = particle.direction_cosine.clone();
 
     let mut facet_coords: [MCVector<T>; N_POINTS_PER_FACET] = Default::default();
@@ -320,7 +320,7 @@ fn mct_nf_find_nearest<T: CustomFloat>(
     let two: T = FromPrimitive::from_f64(2.0).unwrap();
     let threshold: T = FromPrimitive::from_f64(1.0e-2).unwrap();
 
-    let coord = &mut particle.coordinate;
+    let coord = &mut particle.base_particle.coordinate;
 
     const MAX_ALLOWED_SEGMENTS: usize = 10000000;
     const MAX_ITERATION: usize = 1000;
@@ -330,7 +330,8 @@ fn mct_nf_find_nearest<T: CustomFloat>(
 
     // take an option as arg and check if is_some ?
     if (nearest_facet.distance_to_facet == huge_f) & (*move_factor > zero::<T>())
-        | ((particle.num_segments > max) & (nearest_facet.distance_to_facet <= zero()))
+        | ((particle.base_particle.num_segments > max)
+            & (nearest_facet.distance_to_facet <= zero()))
     {
         mct_nf_3dg_move_particle(domain, location, coord, *move_factor);
         *iteration += 1;

--- a/src/simulation/population_control.rs
+++ b/src/simulation/population_control.rs
@@ -228,9 +228,7 @@ pub fn source_now<T: CustomFloat>(mcco: &mut MonteCarlo<T>, container: &mut Part
                             sample * range + mcco.params.simulation_params.e_min;
 
                         let speed: T = speed_from_energy(particle.kinetic_energy);
-                        particle.velocity.x = speed * direction_cosine.alpha;
-                        particle.velocity.y = speed * direction_cosine.beta;
-                        particle.velocity.z = speed * direction_cosine.gamma;
+                        particle.velocity = direction_cosine.dir * speed;
 
                         particle.domain = domain_idx;
                         particle.cell = cell_idx;

--- a/src/simulation/population_control.rs
+++ b/src/simulation/population_control.rs
@@ -212,40 +212,42 @@ pub fn source_now<T: CustomFloat>(mcco: &mut MonteCarlo<T>, container: &mut Part
 
                         rand_n_seed += cell.id as u64;
 
-                        particle.random_number_seed = spawn_rn_seed::<T>(&mut rand_n_seed);
-                        particle.identifier = rand_n_seed;
+                        particle.base_particle.random_number_seed =
+                            spawn_rn_seed::<T>(&mut rand_n_seed);
+                        particle.base_particle.identifier = rand_n_seed;
 
-                        particle.coordinate = generate_coordinate_3dg(
-                            &mut particle.random_number_seed,
+                        particle.base_particle.coordinate = generate_coordinate_3dg(
+                            &mut particle.base_particle.random_number_seed,
                             dom,
                             cell_idx,
                         );
 
                         particle
                             .direction_cosine
-                            .sample_isotropic(&mut particle.random_number_seed);
+                            .sample_isotropic(&mut particle.base_particle.random_number_seed);
 
                         // sample energy uniformly in [emin; emax] MeV
                         let range = mcco.params.simulation_params.e_max
                             - mcco.params.simulation_params.e_min;
-                        let sample: T = rng_sample(&mut particle.random_number_seed);
-                        particle.kinetic_energy =
+                        let sample: T = rng_sample(&mut particle.base_particle.random_number_seed);
+                        particle.base_particle.kinetic_energy =
                             sample * range + mcco.params.simulation_params.e_min;
 
-                        let speed: T = speed_from_energy(particle.kinetic_energy);
-                        particle.velocity.x = speed * particle.direction_cosine.alpha;
-                        particle.velocity.y = speed * particle.direction_cosine.beta;
-                        particle.velocity.z = speed * particle.direction_cosine.gamma;
+                        let speed: T = speed_from_energy(particle.base_particle.kinetic_energy);
+                        particle.base_particle.velocity.x = speed * particle.direction_cosine.alpha;
+                        particle.base_particle.velocity.y = speed * particle.direction_cosine.beta;
+                        particle.base_particle.velocity.z = speed * particle.direction_cosine.gamma;
 
-                        particle.domain = domain_idx;
-                        particle.cell = cell_idx;
+                        particle.base_particle.domain = domain_idx;
+                        particle.base_particle.cell = cell_idx;
                         particle.task = 0; // used task_idx in original code but it stayed const
-                        particle.weight = source_particle_weight;
+                        particle.base_particle.weight = source_particle_weight;
 
-                        let mut rand_f: T = rng_sample(&mut particle.random_number_seed);
-                        particle.num_mean_free_paths = -one::<T>() * rand_f.ln();
-                        rand_f = rng_sample(&mut particle.random_number_seed);
-                        particle.time_to_census = time_step * rand_f;
+                        let mut rand_f: T =
+                            rng_sample(&mut particle.base_particle.random_number_seed);
+                        particle.base_particle.num_mean_free_paths = -one::<T>() * rand_f.ln();
+                        rand_f = rng_sample(&mut particle.base_particle.random_number_seed);
+                        particle.base_particle.time_to_census = time_step * rand_f;
 
                         let base_particle: MCBaseParticle<T> = MCBaseParticle::new(&particle);
                         container.processing_particles.push(base_particle);

--- a/src/simulation/population_control.rs
+++ b/src/simulation/population_control.rs
@@ -11,12 +11,9 @@ use crate::{
         physical::{LIGHT_SPEED, NEUTRON_REST_MASS_ENERGY},
         CustomFloat,
     },
-    data::tallies::Balance,
+    data::{direction_cosine::DirectionCosine, tallies::Balance},
     montecarlo::MonteCarlo,
-    particles::{
-        mc_base_particle::MCBaseParticle, mc_particle::MCParticle,
-        particle_container::ParticleContainer,
-    },
+    particles::{mc_base_particle::MCBaseParticle, particle_container::ParticleContainer},
     simulation::mct::generate_coordinate_3dg,
     utils::mc_rng_state::{rng_sample, spawn_rn_seed},
 };
@@ -204,7 +201,7 @@ pub fn source_now<T: CustomFloat>(mcco: &mut MonteCarlo<T>, container: &mut Part
                         .unwrap();
                     cell_source_tally[cell_idx] = cell.source_tally;
                     (0..cell_n_particles).for_each(|_ii| {
-                        let mut particle: MCParticle<T> = MCParticle::default();
+                        let mut particle: MCBaseParticle<T> = MCBaseParticle::default();
 
                         // atomic in original code
                         let mut rand_n_seed = cell_source_tally[cell_idx] as u64;
@@ -212,48 +209,43 @@ pub fn source_now<T: CustomFloat>(mcco: &mut MonteCarlo<T>, container: &mut Part
 
                         rand_n_seed += cell.id as u64;
 
-                        particle.base_particle.random_number_seed =
-                            spawn_rn_seed::<T>(&mut rand_n_seed);
-                        particle.base_particle.identifier = rand_n_seed;
+                        particle.random_number_seed = spawn_rn_seed::<T>(&mut rand_n_seed);
+                        particle.identifier = rand_n_seed;
 
-                        particle.base_particle.coordinate = generate_coordinate_3dg(
-                            &mut particle.base_particle.random_number_seed,
+                        particle.coordinate = generate_coordinate_3dg(
+                            &mut particle.random_number_seed,
                             dom,
                             cell_idx,
                         );
-
-                        particle
-                            .direction_cosine
-                            .sample_isotropic(&mut particle.base_particle.random_number_seed);
+                        let mut direction_cosine = DirectionCosine::default();
+                        direction_cosine.sample_isotropic(&mut particle.random_number_seed);
 
                         // sample energy uniformly in [emin; emax] MeV
                         let range = mcco.params.simulation_params.e_max
                             - mcco.params.simulation_params.e_min;
-                        let sample: T = rng_sample(&mut particle.base_particle.random_number_seed);
-                        particle.base_particle.kinetic_energy =
+                        let sample: T = rng_sample(&mut particle.random_number_seed);
+                        particle.kinetic_energy =
                             sample * range + mcco.params.simulation_params.e_min;
 
-                        let speed: T = speed_from_energy(particle.base_particle.kinetic_energy);
-                        particle.base_particle.velocity.x = speed * particle.direction_cosine.alpha;
-                        particle.base_particle.velocity.y = speed * particle.direction_cosine.beta;
-                        particle.base_particle.velocity.z = speed * particle.direction_cosine.gamma;
+                        let speed: T = speed_from_energy(particle.kinetic_energy);
+                        particle.velocity.x = speed * direction_cosine.alpha;
+                        particle.velocity.y = speed * direction_cosine.beta;
+                        particle.velocity.z = speed * direction_cosine.gamma;
 
-                        particle.base_particle.domain = domain_idx;
-                        particle.base_particle.cell = cell_idx;
-                        particle.task = 0; // used task_idx in original code but it stayed const
-                        particle.base_particle.weight = source_particle_weight;
+                        particle.domain = domain_idx;
+                        particle.cell = cell_idx;
+                        particle.weight = source_particle_weight;
 
-                        let mut rand_f: T =
-                            rng_sample(&mut particle.base_particle.random_number_seed);
-                        particle.base_particle.num_mean_free_paths = -one::<T>() * rand_f.ln();
-                        rand_f = rng_sample(&mut particle.base_particle.random_number_seed);
-                        particle.base_particle.time_to_census = time_step * rand_f;
+                        let mut rand_f: T = rng_sample(&mut particle.random_number_seed);
+                        particle.num_mean_free_paths = -one::<T>() * rand_f.ln();
+                        rand_f = rng_sample(&mut particle.random_number_seed);
+                        particle.time_to_census = time_step * rand_f;
 
-                        let base_particle: MCBaseParticle<T> = MCBaseParticle::new(&particle);
-                        container.processing_particles.push(base_particle);
+                        container.processing_particles.push(particle);
 
                         // atomic in original code
-                        mcco.tallies.balance_task[particle.task].source += 1;
+                        //mcco.tallies.balance_task[particle.task].source += 1;
+                        mcco.tallies.balance_task[0].source += 1;
                     });
                 });
             // update source_tally


### PR DESCRIPTION
- Inserted the `MCBaseParticle` object directly into `MCParticle` to avoid field-by-field copies and make constructor simpler
- Changed `DirectionCosine` structure to use an `MCVector` object and its defined operators