### PR TITLE
Loop rewrite

### DIFF
--- a/src/data/send_queue.rs
+++ b/src/data/send_queue.rs
@@ -28,11 +28,6 @@ pub struct SendQueue<T: CustomFloat> {
 }
 
 impl<T: CustomFloat> SendQueue<T> {
-    /// Get the total size of the SendQueue.
-    pub fn size(&self) -> usize {
-        self.data.len()
-    }
-
     /// Reserve capacity for the queue.
     pub fn reserve(&mut self, size: usize) {
         if self.data.capacity() < size {
@@ -43,12 +38,12 @@ impl<T: CustomFloat> SendQueue<T> {
     /// Get the number of items in SendQueue going to a specific neighbor.
     /// See if it's used and how much it's used. Maybe returning directly a
     /// filtered iterator is more useful.
-    pub fn neighbor_size(&self, index: usize) -> u64 {
+    pub fn neighbor_size(&self, index: usize) -> usize {
         self.data
             .clone()
             .into_iter()
             .filter(|t| t.neighbor == index)
-            .count() as u64
+            .count()
     }
 
     /// Add items to the SendQueue.
@@ -79,7 +74,7 @@ mod tests {
         };
         let mut queue = SendQueue { data: vec![tt; 10] };
 
-        assert_eq!(queue.size(), 10);
+        assert_eq!(queue.data.len(), 10);
         queue.reserve(20);
         assert_eq!(queue.data.capacity(), 20);
     }
@@ -136,11 +131,11 @@ mod tests {
         pp.base_particle.identifier = 23;
         queue.push(3, &pp);
 
-        assert_eq!(queue.size(), 5);
-        assert_eq!(queue.data[queue.size() - 1], ttt);
+        assert_eq!(queue.data.len(), 5);
+        assert_eq!(queue.data[queue.data.len() - 1], ttt);
 
         queue.clear();
 
-        assert_eq!(queue.size(), 0);
+        assert_eq!(queue.data.len(), 0);
     }
 }

--- a/src/data/tallies.rs
+++ b/src/data/tallies.rs
@@ -52,19 +52,6 @@ pub struct Fluence<T: CustomFloat> {
     pub domain: Vec<FluenceDomain<T>>,
 }
 
-impl<T: CustomFloat> Fluence<T> {
-    pub fn compute(&mut self, domain_idx: usize, scalar_flux_domain: &ScalarFluxDomain<T>) {
-        let n_cells = scalar_flux_domain.cell.len();
-        (0..n_cells).for_each(|cell_idx| {
-            let n_groups = scalar_flux_domain.cell[cell_idx].len();
-            (0..n_groups).for_each(|group_idx| {
-                self.domain[domain_idx]
-                    .add_to_cell(cell_idx, scalar_flux_domain.cell[cell_idx][group_idx]);
-            });
-        });
-    }
-}
-
 /// Domain-sorted fluence-data-holding sub-structure.
 #[derive(Debug, Default)]
 pub struct FluenceDomain<T: CustomFloat> {
@@ -77,10 +64,6 @@ impl<T: CustomFloat> FluenceDomain<T> {
         cell_iter.for_each(|(fl_cell, sf_cell)| {
             *fl_cell += sf_cell.iter().copied().sum();
         })
-    }
-
-    pub fn add_to_cell(&mut self, index: usize, val: T) {
-        self.cell[index] += val;
     }
 
     pub fn size(&self) -> usize {
@@ -97,9 +80,6 @@ impl<T: CustomFloat> FluenceDomain<T> {
 /// During the simulation, each time an event of interest occurs, the counters
 /// are incremented accordingly. In a parallel context, this structure should be
 /// operated on using atomic operations.
-///
-/// CANDIDATE FOR VECTORIZATION: use a `Vec<u64>` & write `add()` method in a way
-/// that allow vectorization (no bound checks)
 #[derive(Debug, Default, Clone)]
 pub struct Balance {
     /// Number of particles absorbed.
@@ -399,15 +379,5 @@ impl<T: CustomFloat> Tallies<T> {
             ct_domain.reset();
             sf_domain.reset();
         });
-        /*
-        (0..self.scalar_flux_domain.len()).for_each(|domain_idx| {
-            if bench_type != BenchType::Standard {
-                self.fluence
-                    .compute(domain_idx, &self.scalar_flux_domain[domain_idx]);
-            }
-            self.cell_tally_domain[domain_idx].reset();
-            self.scalar_flux_domain[domain_idx].reset();
-        });
-        */
     }
 }

--- a/src/data/tallies.rs
+++ b/src/data/tallies.rs
@@ -357,23 +357,18 @@ impl<T: CustomFloat> Tallies<T> {
 
     /// Computes the global scalar flux value of the problem.
     pub fn scalar_flux_sum(&self) -> T {
-        let mut sum: T = zero();
-
-        let n_domain = self.scalar_flux_domain.len();
-        // for all domains
-        (0..n_domain).for_each(|domain_idx| {
-            let n_cells = self.scalar_flux_domain[domain_idx].cell.len();
-            // for each cell
-            (0..n_cells).for_each(|cell_idx| {
-                let n_groups = self.scalar_flux_domain[domain_idx].cell[cell_idx].len();
-                // for each energy group
-                (0..n_groups).for_each(|group_idx| {
-                    sum += self.scalar_flux_domain[domain_idx].cell[cell_idx][group_idx];
-                })
+        let summ: T = self
+            .scalar_flux_domain
+            .iter()
+            .map(|sf_domain| {
+                sf_domain
+                    .cell
+                    .iter()
+                    .map(|sf_cell| sf_cell.iter().copied().sum())
+                    .sum()
             })
-        });
-
-        sum
+            .sum();
+        summ
     }
 
     /// Print stats of the current cycle and update the cumulative counters.

--- a/src/data/tallies.rs
+++ b/src/data/tallies.rs
@@ -6,7 +6,7 @@
 //! Note that this module isn't used to compute time-related data, this is done in
 //! the [utils::mc_fast_timer][crate::utils::mc_fast_timer] module.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, iter::zip};
 
 use num::zero;
 
@@ -184,15 +184,15 @@ impl<T: CustomFloat> ScalarFluxDomain<T> {
     }
 
     /// Add another [ScalarFluxDomain]'s value to its own.
-    ///
-    /// CANDIDATE FOR VECTORIZATION: Rewrite to avoid bound checks
-    pub fn add(&mut self, scalar_flux_domain: &ScalarFluxDomain<T>) {
-        let n_groups = self.cell[0].len();
-        (0..self.cell.len()).for_each(|cell_idx| {
-            (0..n_groups).for_each(|group_idx| {
-                self.cell[cell_idx][group_idx] += scalar_flux_domain.cell[cell_idx][group_idx];
-            })
-        });
+    pub fn add(&mut self, other: &ScalarFluxDomain<T>) {
+        // zip iterators from the two objects' values.
+        let cell_iter = zip(self.cell.iter_mut(), other.cell.iter());
+        cell_iter.for_each(|(cell_lhs, cell_rhs)| {
+            // zip iterators from the two objects' values.
+            let group_iter = zip(cell_lhs.iter_mut(), cell_rhs.iter());
+            // sum other to self
+            group_iter.for_each(|(group_lhs, group_rhs)| *group_lhs += *group_rhs);
+        })
     }
 }
 
@@ -220,10 +220,11 @@ impl<T: CustomFloat> CellTallyDomain<T> {
     }
 
     /// Add another [CellTallyDomain]'s value to its own.
-    ///
-    /// CANDIDATE FOR VECTORIZATION: Rewrite to avoid bound checks
-    pub fn add(&mut self, cell_tally_domain: &CellTallyDomain<T>) {
-        (0..self.cell.len()).for_each(|ii| self.cell[ii] += cell_tally_domain.cell[ii]);
+    pub fn add(&mut self, other: &CellTallyDomain<T>) {
+        // zip iterators from the two objects' values.
+        let iter = zip(self.cell.iter_mut(), other.cell.iter());
+        // sum other to self
+        iter.for_each(|(lhs, rhs)| *lhs += *rhs);
     }
 }
 

--- a/src/geometry/mc_domain.rs
+++ b/src/geometry/mc_domain.rs
@@ -179,7 +179,7 @@ impl<T: CustomFloat> MCDomain<T> {
         (0..mcdomain.cell_state.len()).for_each(|ii| {
             mcdomain.cell_state[ii].volume = mcdomain.cell_volume(ii);
 
-            let rr = cell_position_3dg(&mcdomain, ii);
+            let rr = cell_position_3dg(&mcdomain.mesh, ii);
             let mat_name = Self::find_material(&params.geometry_params, &rr);
             mcdomain.cell_state[ii].material = mat_db.find_material(&mat_name).unwrap();
             mcdomain.cell_state[ii].total = vec![zero(); num_energy_groups];

--- a/src/geometry/mc_domain.rs
+++ b/src/geometry/mc_domain.rs
@@ -198,7 +198,7 @@ impl<T: CustomFloat> MCDomain<T> {
     pub fn clear_cross_section_cache(&mut self) {
         self.cell_state
             .iter_mut()
-            .for_each(|cs| cs.total = vec![zero(); cs.total.len()])
+            .for_each(|cs| cs.total.fill(zero()))
     }
 
     fn find_material(geometry_params: &[GeometryParameters<T>], rr: &MCVector<T>) -> String {

--- a/src/init.rs
+++ b/src/init.rs
@@ -278,8 +278,11 @@ fn init_mesh<T: CustomFloat>(mcco: &mut MonteCarlo<T>) {
 
 fn init_tallies<T: CustomFloat>(mcco: &mut MonteCarlo<T>) {
     let params = &mcco.params;
-    mcco.tallies
-        .initialize_tallies(&mcco.domain, params.simulation_params.n_groups)
+    mcco.tallies.initialize_tallies(
+        &mcco.domain,
+        params.simulation_params.n_groups,
+        params.simulation_params.coral_benchmark,
+    )
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,12 +135,12 @@ pub fn cycle_finalize<T: CustomFloat>(
 ) {
     mc_fast_timer::start(mcco, Section::CycleFinalize);
 
-    // prepare data for summary
+    // prepare data for summary; this would be a sync phase in parallel exec
     mcco.tallies.balance_cycle.end = container.processed_particles.len() as u64;
+
     // print summary
-    //mc_fast_timer::stop(mcco, Section::CycleFinalize);
     mcco.tallies.print_summary(mcco);
-    mc_fast_timer::start(mcco, Section::CycleFinalize);
+
     // record / process data for the next cycle
     mcco.tallies
         .cycle_finalize(mcco.params.simulation_params.coral_benchmark);

--- a/src/simulation/population_control.rs
+++ b/src/simulation/population_control.rs
@@ -148,16 +148,20 @@ pub fn roulette_low_weight_particles<T: CustomFloat>(
 pub fn source_now<T: CustomFloat>(mcco: &mut MonteCarlo<T>, container: &mut ParticleContainer<T>) {
     let time_step = mcco.time_info.time_step;
 
+    // this is a constant; add it to mcco ?
     let mut source_rate: Vec<T> = vec![zero(); mcco.material_database.mat.len()];
-    (0..mcco.material_database.mat.len()).for_each(|mat_idx| {
-        let name = &mcco.material_database.mat[mat_idx].name;
-        let sr = mcco.params.material_params[name].source_rate;
-        source_rate[mat_idx] = sr;
-    });
+    source_rate
+        .iter_mut()
+        .zip(mcco.material_database.mat.iter())
+        .for_each(|(lhs, mat)| {
+            let rhs = mcco.params.material_params[&mat.name].source_rate;
+            *lhs = rhs;
+        });
 
     let mut total_weight_particles: T = zero();
     mcco.domain.iter().for_each(|dom| {
         dom.cell_state.iter().for_each(|cell| {
+            // constant because cell volume is constant in our program
             let cell_weight_particles: T = cell.volume * source_rate[cell.material] * time_step;
             total_weight_particles += cell_weight_particles;
         });


### PR DESCRIPTION
- changed indexed loop to make use of iterators
- loops of initialization code are mostly left unchanged
- two main functions are still heavily dependent on indexes: `source_now()` & everything in the `macro_cross_section` module