### PR TITLE
Borrow optimization

### DIFF
--- a/src/simulation/cycle_tracking.rs
+++ b/src/simulation/cycle_tracking.rs
@@ -72,7 +72,21 @@ fn cycle_tracking_function<T: CustomFloat>(
 
         match segment_outcome {
             MCSegmentOutcome::Collision => {
-                keep_tracking = collision_event(mcdata, mcunit, particle, extra);
+                let mat_gid = mcunit.domain[particle.base_particle.domain].cell_state
+                    [particle.base_particle.cell]
+                    .material;
+                let cell_nb_density = mcunit.domain[particle.base_particle.domain].cell_state
+                    [particle.base_particle.cell]
+                    .cell_number_density;
+
+                keep_tracking = collision_event(
+                    mcdata,
+                    mat_gid,
+                    cell_nb_density,
+                    particle,
+                    extra,
+                    &mut mcunit.tallies.balance_cycle,
+                );
                 if !keep_tracking {
                     particle.base_particle.species = Species::Unknown;
                 }

--- a/src/simulation/cycle_tracking.rs
+++ b/src/simulation/cycle_tracking.rs
@@ -104,7 +104,12 @@ fn cycle_tracking_function<T: CustomFloat>(
                         false
                     }
                     MCTallyEvent::FacetCrossingReflection => {
-                        reflect_particle(mcunit, particle);
+                        // plane on which particle is reflected
+                        let plane = &mcunit.domain[particle.base_particle.domain]
+                            .mesh
+                            .cell_geometry[particle.base_particle.cell][particle.facet];
+
+                        reflect_particle(particle, plane);
                         true
                     }
                     _ => {

--- a/src/simulation/macro_cross_section.rs
+++ b/src/simulation/macro_cross_section.rs
@@ -5,10 +5,7 @@
 
 use num::{zero, FromPrimitive};
 
-use crate::{
-    constants::CustomFloat,
-    montecarlo::{MonteCarloData, MonteCarloUnit},
-};
+use crate::{constants::CustomFloat, montecarlo::MonteCarloData};
 
 /// Computes the reaction-specific number-density-weighted
 /// macroscopic cross section in the cell.
@@ -17,32 +14,30 @@ use crate::{
 /// only accounts for simulation of a single isotope type.
 pub fn macroscopic_cross_section<T: CustomFloat>(
     mcdata: &MonteCarloData<T>,
-    mcunit: &MonteCarloUnit<T>,
     reaction_idx: usize,
-    domain_idx: usize,
-    cell_idx: usize,
+    mat_gid: usize,
+    cell_nb_density: T,
     isotope_idx: usize,
     energy_group: usize,
 ) -> T {
-    let global_mat_idx = mcunit.domain[domain_idx].cell_state[cell_idx].material;
+    //let global_mat_idx = mcunit.domain[domain_idx].cell_state[cell_idx].material;
 
-    let atom_fraction: T =
-        mcdata.material_database.mat[global_mat_idx].iso[isotope_idx].atom_fraction;
-    let cell_number_density: T = mcunit.domain[domain_idx].cell_state[cell_idx].cell_number_density;
+    let atom_fraction: T = mcdata.material_database.mat[mat_gid].iso[isotope_idx].atom_fraction;
+    //let cell_number_density: T = mcunit.domain[domain_idx].cell_state[cell_idx].cell_number_density;
 
-    if (atom_fraction == zero()) | (cell_number_density == zero()) {
+    if (atom_fraction == zero()) | (cell_nb_density == zero()) {
         // one of the two is 0
         let res: T = FromPrimitive::from_f64(1e-20).unwrap();
         return res;
     }
 
-    let isotope_gid = mcdata.material_database.mat[global_mat_idx].iso[isotope_idx].gid;
+    let isotope_gid = mcdata.material_database.mat[mat_gid].iso[isotope_idx].gid;
     let micro_cross_section: T =
         mcdata
             .nuclear_data
             .get_reaction_cross_section(reaction_idx, isotope_gid, energy_group);
 
-    atom_fraction * cell_number_density * micro_cross_section
+    atom_fraction * cell_nb_density * micro_cross_section
 }
 
 /// Computes the total number-density-weighted macroscopic

--- a/src/simulation/macro_cross_section.rs
+++ b/src/simulation/macro_cross_section.rs
@@ -52,30 +52,25 @@ pub fn macroscopic_cross_section<T: CustomFloat>(
 /// only accounts for simulation of a single isotope type.
 fn macroscopic_total_cross_section<T: CustomFloat>(
     mcdata: &MonteCarloData<T>,
-    mcunit: &MonteCarloUnit<T>,
-    domain_idx: usize,
-    cell_idx: usize,
+    mat_gid: usize,
     isotope_idx: usize,
+    cell_nb_density: T,
     energy_group: usize,
 ) -> T {
-    let global_mat_idx = mcunit.domain[domain_idx].cell_state[cell_idx].material;
+    let atom_fraction: T = mcdata.material_database.mat[mat_gid].iso[isotope_idx].atom_fraction;
 
-    let atom_fraction: T =
-        mcdata.material_database.mat[global_mat_idx].iso[isotope_idx].atom_fraction;
-    let cell_number_density: T = mcunit.domain[domain_idx].cell_state[cell_idx].cell_number_density;
-
-    if (atom_fraction == zero()) | (cell_number_density == zero()) {
+    if (atom_fraction == zero()) | (cell_nb_density == zero()) {
         // one of the two is 0
         let res: T = FromPrimitive::from_f64(1e-20).unwrap();
         return res;
     }
 
-    let isotope_gid = mcdata.material_database.mat[global_mat_idx].iso[isotope_idx].gid;
+    let isotope_gid = mcdata.material_database.mat[mat_gid].iso[isotope_idx].gid;
     let micro_cross_section: T = mcdata
         .nuclear_data
         .get_total_cross_section(isotope_gid, energy_group);
 
-    atom_fraction * cell_number_density * micro_cross_section
+    atom_fraction * cell_nb_density * micro_cross_section
 }
 
 /// Computes the number-density-weighted macroscopic cross section
@@ -85,28 +80,24 @@ fn macroscopic_total_cross_section<T: CustomFloat>(
 /// choice of Quicksilver to leave material weighting out of the proxy-app.
 pub fn weighted_macroscopic_cross_section<T: CustomFloat>(
     mcdata: &MonteCarloData<T>,
-    mcunit: &mut MonteCarloUnit<T>,
-    domain_idx: usize,
-    cell_idx: usize,
+    mat_gid: usize,
+    cell_nb_density: T,
     energy_group: usize,
 ) -> T {
     let mut sum: T = zero();
-    let global_material_idx: usize = mcunit.domain[domain_idx].cell_state[cell_idx].material;
-    let n_isotopes: usize = mcdata.material_database.mat[global_material_idx].iso.len();
+    //let global_material_idx: usize = mcunit.domain[domain_idx].cell_state[cell_idx].material;
+    let n_isotopes: usize = mcdata.material_database.mat[mat_gid].iso.len();
+    //let cnd: T = mcunit.domain[domain_idx].cell_state[cell_idx].cell_number_density;
 
     (0..n_isotopes).for_each(|isotope_idx| {
         sum += macroscopic_total_cross_section(
             mcdata,
-            mcunit,
-            domain_idx,
-            cell_idx,
+            mat_gid,
             isotope_idx,
+            cell_nb_density,
             energy_group,
         )
     });
-
-    // atomic in original code
-    mcunit.domain[domain_idx].cell_state[cell_idx].total[energy_group] = sum;
 
     sum
 }

--- a/src/simulation/macro_cross_section.rs
+++ b/src/simulation/macro_cross_section.rs
@@ -20,10 +20,7 @@ pub fn macroscopic_cross_section<T: CustomFloat>(
     isotope_idx: usize,
     energy_group: usize,
 ) -> T {
-    //let global_mat_idx = mcunit.domain[domain_idx].cell_state[cell_idx].material;
-
     let atom_fraction: T = mcdata.material_database.mat[mat_gid].iso[isotope_idx].atom_fraction;
-    //let cell_number_density: T = mcunit.domain[domain_idx].cell_state[cell_idx].cell_number_density;
 
     if (atom_fraction == zero()) | (cell_nb_density == zero()) {
         // one of the two is 0
@@ -80,9 +77,7 @@ pub fn weighted_macroscopic_cross_section<T: CustomFloat>(
     energy_group: usize,
 ) -> T {
     let mut sum: T = zero();
-    //let global_material_idx: usize = mcunit.domain[domain_idx].cell_state[cell_idx].material;
     let n_isotopes: usize = mcdata.material_database.mat[mat_gid].iso.len();
-    //let cnd: T = mcunit.domain[domain_idx].cell_state[cell_idx].cell_number_density;
 
     (0..n_isotopes).for_each(|isotope_idx| {
         sum += macroscopic_total_cross_section(

--- a/src/simulation/macro_cross_section.rs
+++ b/src/simulation/macro_cross_section.rs
@@ -90,14 +90,6 @@ pub fn weighted_macroscopic_cross_section<T: CustomFloat>(
     cell_idx: usize,
     energy_group: usize,
 ) -> T {
-    // early return
-    // this willbe moved before the call to this fucntion
-    let precomputed_cross_section =
-        mcunit.domain[domain_idx].cell_state[cell_idx].total[energy_group];
-    if precomputed_cross_section > zero() {
-        return precomputed_cross_section;
-    }
-
     let mut sum: T = zero();
     let global_material_idx: usize = mcunit.domain[domain_idx].cell_state[cell_idx].material;
     let n_isotopes: usize = mcdata.material_database.mat[global_material_idx].iso.len();

--- a/src/simulation/mc_facet_crossing_event.rs
+++ b/src/simulation/mc_facet_crossing_event.rs
@@ -15,7 +15,7 @@ use crate::{
 /// This functions update a particle's locational data according to one of the
 /// four defined adjacency events ([MCSubfacetAdjacencyEvent]). Note that in a
 /// sequential or a memory-shared parallelism context, there are no off-processor
-/// transit.
+/// transit as the mesh is not divided for management.
 pub fn facet_crossing_event<T: CustomFloat>(
     particle: &mut MCParticle<T>,
     facet_adjacency: &SubfacetAdjacency,

--- a/src/simulation/mc_facet_crossing_event.rs
+++ b/src/simulation/mc_facet_crossing_event.rs
@@ -22,12 +22,11 @@ pub fn facet_crossing_event<T: CustomFloat>(
     mcunit: &MonteCarloUnit<T>,
     send_queue: &mut SendQueue<T>,
 ) {
-    let location = particle.get_location();
-    let facet_adjacency = &mcunit.domain[location.domain.unwrap()]
+    let facet_adjacency = &mcunit.domain[particle.base_particle.domain]
         .mesh
-        .cell_connectivity[location.cell.unwrap()]
-    .facet[location.facet.unwrap()]
-    .subfacet;
+        .cell_connectivity[particle.base_particle.cell]
+        .facet[particle.facet]
+        .subfacet;
 
     match facet_adjacency.event {
         MCSubfacetAdjacencyEvent::TransitOnProcessor => {

--- a/src/simulation/mc_segment_outcome.rs
+++ b/src/simulation/mc_segment_outcome.rs
@@ -124,7 +124,8 @@ pub fn outcome<T: CustomFloat>(
         particle_speed * particle.base_particle.time_to_census;
 
     // nearest facet
-    let nearest_facet: MCNearestFacet<T> = nearest_facet(particle, mcunit);
+    let nearest_facet: MCNearestFacet<T> =
+        nearest_facet(particle, &mcunit.domain[particle.base_particle.domain]);
     particle.normal_dot = nearest_facet.dot_product;
     distance[MCSegmentOutcome::FacetCrossing as usize] = nearest_facet.distance_to_facet;
 

--- a/src/simulation/mc_segment_outcome.rs
+++ b/src/simulation/mc_segment_outcome.rs
@@ -76,11 +76,17 @@ pub fn outcome<T: CustomFloat>(
         precomputed_cross_section
     } else {
         // compute XS
+        let mat_gid: usize = mcunit.domain[particle.base_particle.domain].cell_state
+            [particle.base_particle.cell]
+            .material;
+        let cell_nb_density: T = mcunit.domain[particle.base_particle.domain].cell_state
+            [particle.base_particle.cell]
+            .cell_number_density;
+
         let tmp = weighted_macroscopic_cross_section(
             mcdata,
-            mcunit,
-            particle.base_particle.domain,
-            particle.base_particle.cell,
+            mat_gid,
+            cell_nb_density,
             particle.energy_group,
         );
 

--- a/src/simulation/mct.rs
+++ b/src/simulation/mct.rs
@@ -15,7 +15,6 @@ use crate::{
         mc_location::MCLocation,
         N_FACETS_OUT, N_POINTS_INTERSEC, N_POINTS_PER_FACET,
     },
-    montecarlo::MonteCarloUnit,
     particles::mc_particle::MCParticle,
     utils::mc_rng_state::rng_sample,
 };
@@ -29,14 +28,8 @@ use crate::{
 /// case, a facet crossing. See [MCNearestFacet] for more information.
 pub fn nearest_facet<T: CustomFloat>(
     particle: &mut MCParticle<T>,
-    mcunit: &MonteCarloUnit<T>,
+    domain: &MCDomain<T>,
 ) -> MCNearestFacet<T> {
-    let location = particle.get_location();
-    if location.domain.is_none() | location.cell.is_none() {
-        panic!()
-    }
-    let domain = &mcunit.domain[location.domain.unwrap()];
-
     let mut nearest_facet = mct_nf_3dg(particle, domain);
 
     if nearest_facet.distance_to_facet < zero() {

--- a/src/simulation/mct.rs
+++ b/src/simulation/mct.rs
@@ -132,12 +132,8 @@ pub fn cell_position_3dg<T: CustomFloat>(mesh: &MCMeshDomain<T>, cell_idx: usize
 /// This function is called when a particle undergo a reflectionevent at the
 /// boundary of the problem. Note that the reflection does not result in a
 /// loss of energy.
-pub fn reflect_particle<T: CustomFloat>(mcunit: &MonteCarloUnit<T>, particle: &mut MCParticle<T>) {
+pub fn reflect_particle<T: CustomFloat>(particle: &mut MCParticle<T>, plane: &MCGeneralPlane<T>) {
     let mut new_d_cos = particle.direction_cosine.clone();
-    let location = particle.get_location();
-
-    let domain = &mcunit.domain[location.domain.unwrap()];
-    let plane = &domain.mesh.cell_geometry[location.cell.unwrap()][location.facet.unwrap()];
 
     let facet_normal: MCVector<T> = MCVector {
         x: plane.a,


### PR DESCRIPTION
- Updated many functions signatures to use bare minimum borrows/arguments instead of passing full structures

Note: this refactor stresses the importance of handling the `MCParticle` / `MCBaseParticle` problem