### PR TITLE
Misc optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "num",
  "rand",
  "serde_yaml",
+ "tinyvec",
 ]
 
 [[package]]
@@ -763,6 +764,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,12 @@ clap = {version="4.1.4", features=["cargo", "derive"]}
 serde_yaml = {version="0.9.17", features=[]}
 num = {version="0.4.0"}
 rand = {version="0.8.5", features=["small_rng"]}
+tinyvec = {version="1.6.0"}
 
 [profile.release]
 lto = true
 #codegen-units = 1
-debug = true
+#debug = true
 
 [dev-dependencies]
 criterion = {version="0.3.4", features=["html_reports"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rand = {version="0.8.5", features=["small_rng"]}
 [profile.release]
 lto = true
 #codegen-units = 1
+debug = true
 
 [dev-dependencies]
 criterion = {version="0.3.4", features=["html_reports"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tinyvec = {version="1.6.0"}
 [profile.release]
 lto = true
 #codegen-units = 1
-#debug = true
+debug = true
 
 [dev-dependencies]
 criterion = {version="0.3.4", features=["html_reports"]}

--- a/profiling/SequentialAnalysis/README.md
+++ b/profiling/SequentialAnalysis/README.md
@@ -9,7 +9,7 @@ column -s=';' -t < a_file.csv
 ```
 
 Note that this analysis precedes some additional changes to be done to the code 
-before release. See the comparison [section](#rustified-edition-comparison) for more detail.
+before release. See the dedicated [section](#additonal-changes) for more detail.
 
 
 ## Correlation Study
@@ -175,12 +175,23 @@ program. An interesting observation is that the `CycleInit` and `PopulationContr
 values have comparable values despite the deletion of the `MCBaseParticle` structure, 
 hence a supposedly heavier particle initialization.
 
-Two additional changes will be done before release, hence are not taken into account here:
-The usage of [`tinyvec`][3] when sampling for collision and the usage of `Option<usize>`
-in `MCFacetAdjacency`. While the first will mostly influence the memory footprint, the 
-second might lead to an increase in performances when computing the nearest facet during
-tracking.
+## Additional Changes
+
+Three additional changes have been made and are not taken into account in this 
+analysis. They were merged with PR [#62][4]:
+
+- The `sample_collision()` routine has been rewritten as a method for the `MCParticle` 
+  structure. The new structure prevents a vector return and is overall clearer. The 
+  new function also makes use of [`tinyvec`][3] to greatly reduce the number of 
+  allocations.
+- `MCFacetAdjacency` no longer makes use of `Option<>`, this allows for much less
+  unwraps when computing the nearest facet to a particle.
+- The sourcing function has been slightly changed to reduce the number of allocations.
+
+Only the rewrite of `sample_collision()` affect significantly execution time, the 
+other two changes only affect memory footprint in a non-negligible way.
 
 [1]: https://github.com/imrn99/fi_stats
 [2]: https://en.wikipedia.org/wiki/Relative_change_and_difference#Definition
 [3]: https://docs.rs/tinyvec/latest/tinyvec/
+[4]: https://github.com/cea-hpc/fastiron/pull/62

--- a/profiling/SequentialAnalysis/README.md
+++ b/profiling/SequentialAnalysis/README.md
@@ -9,7 +9,7 @@ column -s=';' -t < a_file.csv
 ```
 
 Note that this analysis precedes some additional changes to be done to the code 
-before release. See the dedicated [section](#additonal-changes) for more detail.
+before release. See the dedicated [section](#additional-changes) for more detail.
 
 
 ## Correlation Study
@@ -174,6 +174,7 @@ The population control functions have been integrated in the processing section 
 program. An interesting observation is that the `CycleInit` and `PopulationControl` 
 values have comparable values despite the deletion of the `MCBaseParticle` structure, 
 hence a supposedly heavier particle initialization.
+
 
 ## Additional Changes
 

--- a/src/geometry/facets.rs
+++ b/src/geometry/facets.rs
@@ -151,22 +151,13 @@ pub struct SubfacetAdjacency {
 }
 
 /// Structure for adjacent facet representation.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MCFacetAdjacency {
     /// Adjacency data.
     pub subfacet: SubfacetAdjacency,
     /// Point indexes for this facet. The points are defined in a private constant
     /// in the [mc_domain][super::mc_domain] module.
-    pub point: [Option<usize>; N_POINTS_PER_FACET],
-}
-
-impl Default for MCFacetAdjacency {
-    fn default() -> Self {
-        Self {
-            subfacet: Default::default(),
-            point: [None; N_POINTS_PER_FACET],
-        }
-    }
+    pub point: [usize; N_POINTS_PER_FACET],
 }
 
 /// Structure encompassing all adjacent facet to a cell.

--- a/src/geometry/mc_domain.rs
+++ b/src/geometry/mc_domain.rs
@@ -122,12 +122,9 @@ impl<T: CustomFloat> MCMeshDomain<T> {
         // fill with correct value
         (0..cell_connectivity.len()).for_each(|cell_idx| {
             (0..N_FACETS_OUT).for_each(|facet_idx| {
-                let r0: MCVector<T> =
-                    node[cell_connectivity[cell_idx].facet[facet_idx].point[0].unwrap()];
-                let r1: MCVector<T> =
-                    node[cell_connectivity[cell_idx].facet[facet_idx].point[1].unwrap()];
-                let r2: MCVector<T> =
-                    node[cell_connectivity[cell_idx].facet[facet_idx].point[2].unwrap()];
+                let r0: MCVector<T> = node[cell_connectivity[cell_idx].facet[facet_idx].point[0]];
+                let r1: MCVector<T> = node[cell_connectivity[cell_idx].facet[facet_idx].point[1]];
+                let r2: MCVector<T> = node[cell_connectivity[cell_idx].facet[facet_idx].point[2]];
                 cell_geometry[cell_idx][facet_idx] = MCGeneralPlane::new(&r0, &r1, &r2);
             });
         });
@@ -256,9 +253,9 @@ impl<T: CustomFloat> MCDomain<T> {
 
         (0..N_FACETS_OUT).for_each(|facet_idx| {
             let corners = &cell.facet[facet_idx].point;
-            let aa: MCVector<T> = node[corners[0].unwrap()] - center;
-            let bb: MCVector<T> = node[corners[1].unwrap()] - center;
-            let cc: MCVector<T> = node[corners[2].unwrap()] - center;
+            let aa: MCVector<T> = node[corners[0]] - center;
+            let bb: MCVector<T> = node[corners[1]] - center;
+            let cc: MCVector<T> = node[corners[2]] - center;
             volume += aa.dot(&bb.cross(&cc)).abs();
         });
         volume /= FromPrimitive::from_f64(6.0).unwrap();
@@ -385,9 +382,9 @@ fn make_facet(
     let facet_id = location.facet.unwrap();
     let face_id = facet_id / 4;
 
-    facet.point[0] = Some(node_idx[NODE_INDIRECT[facet_id][0]]);
-    facet.point[1] = Some(node_idx[NODE_INDIRECT[facet_id][1]]);
-    facet.point[2] = Some(node_idx[NODE_INDIRECT[facet_id][2]]);
+    facet.point[0] = node_idx[NODE_INDIRECT[facet_id][0]];
+    facet.point[1] = node_idx[NODE_INDIRECT[facet_id][1]];
+    facet.point[2] = node_idx[NODE_INDIRECT[facet_id][2]];
     facet.subfacet.event = face_info[face_id].event;
     facet.subfacet.current = *location;
     facet.subfacet.adjacent.domain = face_info[face_id].cell_info.domain_index;

--- a/src/particles/mc_particle.rs
+++ b/src/particles/mc_particle.rs
@@ -6,6 +6,7 @@
 use std::iter::zip;
 
 use num::{one, zero, FromPrimitive};
+use tinyvec::ArrayVec;
 
 use crate::{
     constants::CustomFloat,
@@ -167,20 +168,21 @@ impl<T: CustomFloat> MCParticle<T> {
                         let energy = twenty * rand_f * rand_f;
                         let angle = rng_sample::<T>(&mut self.random_number_seed) * two - one;
 
-                        let out: Vec<(T, T)> = (1..num_particle_out)
-                            .map(|_| {
-                                let rand_f =
-                                    (rng_sample::<T>(&mut self.random_number_seed) + one) / two;
-                                let energy_out = twenty * rand_f * rand_f;
-                                let angle_out =
-                                    rng_sample::<T>(&mut self.random_number_seed) * two - one;
-                                (energy_out, angle_out)
-                            })
-                            .collect();
+                        let mut out = ArrayVec::<[(T, T); 5]>::default();
+                        out.extend((1..num_particle_out).map(|_| {
+                            let rand_f =
+                                (rng_sample::<T>(&mut self.random_number_seed) + one) / two;
+                            let energy_out = twenty * rand_f * rand_f;
+                            let angle_out =
+                                rng_sample::<T>(&mut self.random_number_seed) * two - one;
+                            (energy_out, angle_out)
+                        }));
 
-                        let seeds: Vec<u64> = (1..num_particle_out)
-                            .map(|_| spawn_rn_seed::<T>(&mut self.random_number_seed))
-                            .collect();
+                        let mut seeds = ArrayVec::<[u64; 5]>::default();
+                        seeds.extend(
+                            (1..num_particle_out)
+                                .map(|_| spawn_rn_seed::<T>(&mut self.random_number_seed)),
+                        );
 
                         let sec_particles = zip(seeds, out).map(|(seed, (energy, angle))| {
                             let mut sec_particle = self.clone();

--- a/src/simulation/collision_event.rs
+++ b/src/simulation/collision_event.rs
@@ -4,7 +4,7 @@
 //! from beginning to end. Note that _collision_ refers to reaction with the
 //! particle's environment, not in-between particles.
 
-use num::{one, zero, FromPrimitive};
+use num::zero;
 
 use crate::{
     constants::CustomFloat,
@@ -12,28 +12,8 @@ use crate::{
     montecarlo::MonteCarloData,
     particles::mc_particle::MCParticle,
     simulation::macro_cross_section::macroscopic_cross_section,
-    utils::mc_rng_state::{rng_sample, spawn_rn_seed},
+    utils::mc_rng_state::spawn_rn_seed,
 };
-
-fn update_trajectory<T: CustomFloat>(energy: T, angle: T, particle: &mut MCParticle<T>) {
-    // constants
-    let pi: T = T::pi();
-    let one: T = one();
-    let two: T = FromPrimitive::from_f64(2.0).unwrap();
-
-    // value for update
-    let cos_theta: T = angle;
-    let sin_theta: T = (one - cos_theta * cos_theta).sqrt();
-    let rdm_number: T = rng_sample(&mut particle.random_number_seed);
-    let phi = two * pi * rdm_number;
-    let sin_phi: T = phi.sin();
-    let cos_phi: T = phi.cos();
-
-    // update
-    particle.kinetic_energy = energy;
-    particle.rotate_direction(sin_theta, cos_theta, sin_phi, cos_phi);
-    particle.sample_num_mfp();
-}
 
 /// Transforms a given particle according to an internally drawn type of collision.
 ///
@@ -95,12 +75,13 @@ pub fn collision_event<T: CustomFloat>(
     }
     assert_ne!(selected_iso, usize::MAX); // sort of a magic value
 
+    let mat_mass = mcdata.material_database.mat[mat_gid].mass;
+    let reaction = &mcdata.nuclear_data.isotopes[selected_unique_n][0].reactions[selected_react];
+
     // ================
     // Do the collision
 
-    let mat_mass = mcdata.material_database.mat[mat_gid].mass;
-    let reaction = &mcdata.nuclear_data.isotopes[selected_unique_n][0].reactions[selected_react];
-    let (energy_out, angle_out) = particle.sample_collision(reaction, mat_mass);
+    let (energy_out, angle_out) = particle.sample_collision(reaction, mat_mass, extra);
     // number of particles resulting from the collision, including the original
     // e.g. zero means the original particle was absorbed or invalidated in some way
     let n_out = energy_out.len();
@@ -109,8 +90,7 @@ pub fn collision_event<T: CustomFloat>(
     // Tally the collision
 
     balance.collision += 1; // atomic in original code
-    match mcdata.nuclear_data.isotopes[selected_unique_n][0].reactions[selected_react].reaction_type
-    {
+    match reaction.reaction_type {
         ReactionType::Scatter => balance.scatter += 1,
         ReactionType::Absorption => balance.absorb += 1,
         ReactionType::Fission => {
@@ -133,16 +113,12 @@ pub fn collision_event<T: CustomFloat>(
             let mut sec_particle = particle.clone();
             sec_particle.random_number_seed = spawn_rn_seed::<T>(&mut particle.random_number_seed);
             sec_particle.identifier = sec_particle.random_number_seed;
-            update_trajectory(
-                energy_out[secondary_idx],
-                angle_out[secondary_idx],
-                &mut sec_particle,
-            );
+            sec_particle.update_trajectory(energy_out[secondary_idx], angle_out[secondary_idx]);
             extra.push(sec_particle);
         }
     }
 
-    update_trajectory(energy_out[0], angle_out[0], particle);
+    particle.update_trajectory(energy_out[0], angle_out[0]);
     particle.energy_group = mcdata
         .nuclear_data
         .get_energy_groups(particle.kinetic_energy);
@@ -152,39 +128,4 @@ pub fn collision_event<T: CustomFloat>(
     }
 
     n_out == 1
-}
-
-//=============
-// Unit tests
-//=============
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::data::mc_vector::MCVector;
-    use num::Float;
-
-    #[test]
-    fn trajectory() {
-        let mut pp: MCParticle<f64> = MCParticle::default();
-        // init data
-        let e: f64 = 1.0;
-        pp.direction = MCVector {
-            x: 1.0 / 3.0.sqrt(),
-            y: 1.0 / 3.0.sqrt(),
-            z: 1.0 / 3.0.sqrt(),
-        };
-        pp.kinetic_energy = e;
-        let mut seed: u64 = 90374384094798327;
-        let energy = rng_sample(&mut seed);
-        let angle = rng_sample(&mut seed);
-
-        // update & print result
-        update_trajectory(energy, angle, &mut pp);
-
-        assert!((pp.direction.x - 0.620283).abs() < 1.0e-6);
-        assert!((pp.direction.y - 0.620283).abs() < 1.0e-6);
-        assert!((pp.direction.z - (-0.480102)).abs() < 1.0e-6);
-        assert!((pp.kinetic_energy - energy).abs() < f64::tiny_float());
-    }
 }

--- a/src/simulation/collision_event.rs
+++ b/src/simulation/collision_event.rs
@@ -99,13 +99,8 @@ pub fn collision_event<T: CustomFloat>(
     // Do the collision
 
     let mat_mass = mcdata.material_database.mat[mat_gid].mass;
-    let (energy_out, angle_out) = mcdata.nuclear_data.isotopes[selected_unique_n][0].reactions
-        [selected_react]
-        .sample_collision(
-            particle.kinetic_energy,
-            mat_mass,
-            &mut particle.random_number_seed,
-        );
+    let reaction = &mcdata.nuclear_data.isotopes[selected_unique_n][0].reactions[selected_react];
+    let (energy_out, angle_out) = particle.sample_collision(reaction, mat_mass);
     // number of particles resulting from the collision, including the original
     // e.g. zero means the original particle was absorbed or invalidated in some way
     let n_out = energy_out.len();

--- a/src/simulation/cycle_tracking.rs
+++ b/src/simulation/cycle_tracking.rs
@@ -78,6 +78,9 @@ fn cycle_tracking_function<T: CustomFloat>(
                     extra,
                     &mut mcunit.tallies.balance_cycle,
                 );
+                particle.energy_group = mcdata
+                    .nuclear_data
+                    .get_energy_groups(particle.kinetic_energy);
                 if !keep_tracking {
                     particle.species = Species::Unknown;
                 }

--- a/src/simulation/mc_segment_outcome.rs
+++ b/src/simulation/mc_segment_outcome.rs
@@ -131,13 +131,8 @@ pub fn outcome<T: CustomFloat>(
 
     let segment_outcome = find_min(&distance);
 
-    if distance[segment_outcome as usize] < zero() {
-        println!(
-            "Distance to {segment_outcome:?} negative: {}",
-            distance[segment_outcome as usize]
-        );
-        panic!()
-    }
+    assert!(distance[segment_outcome as usize] >= zero());
+
     particle.segment_path_length = distance[segment_outcome as usize];
     particle.num_mean_free_paths -= particle.segment_path_length / particle.mean_free_path;
 

--- a/src/simulation/mct.rs
+++ b/src/simulation/mct.rs
@@ -188,9 +188,9 @@ fn mct_nf_3dg<T: CustomFloat>(
             // Mesh-dependent code
             let points =
                 domain.mesh.cell_connectivity[location.cell.unwrap()].facet[facet_idx].point;
-            facet_coords[0] = domain.mesh.node[points[0].unwrap()];
-            facet_coords[1] = domain.mesh.node[points[1].unwrap()];
-            facet_coords[2] = domain.mesh.node[points[2].unwrap()];
+            facet_coords[0] = domain.mesh.node[points[0]];
+            facet_coords[1] = domain.mesh.node[points[1]];
+            facet_coords[2] = domain.mesh.node[points[2]];
 
             let t: T = mct_nf_3dg_dist_to_segment(
                 plane_tolerance,
@@ -331,7 +331,7 @@ fn mct_facet_points_3dg<T: CustomFloat>(
     let mut res: [usize; N_POINTS_PER_FACET] = [0; N_POINTS_PER_FACET];
 
     (0..N_POINTS_PER_FACET).for_each(|point_idx| {
-        res[point_idx] = mesh.cell_connectivity[cell].facet[facet].point[point_idx].unwrap();
+        res[point_idx] = mesh.cell_connectivity[cell].facet[facet].point[point_idx];
     });
 
     res


### PR DESCRIPTION
- The `sample_collision()` routine has been rewritten as a method for the `MCParticle` 
  structure. The new structure prevents a vector return and is overall clearer. The 
  new function also makes use of `tinyvec` to greatly reduce the number of 
  allocations.
- `MCFacetAdjacency` no longer makes use of `Option<>`, this allows for much less
  unwraps when computing the nearest facet to a particle.
- The sourcing function has been slightly changed to reduce the number of allocations.
