### PR TITLE
Better  xs cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/config
 /target
 /tmp
 /out

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,55 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,9 +82,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cast"
@@ -68,27 +117,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
  "clap_lex",
- "is-terminal",
  "once_cell",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -96,12 +154,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "criterion"
@@ -141,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -151,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -162,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -175,18 +236,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "csv"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
  "csv-core",
  "itoa",
@@ -211,13 +272,13 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -235,7 +296,7 @@ name = "fastiron"
 version = "1.2.0"
 dependencies = [
  "atomic",
- "clap 4.1.4",
+ "clap 4.3.0",
  "criterion",
  "num",
  "rand",
@@ -253,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -306,9 +367,9 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -316,19 +377,20 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -347,15 +409,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -368,24 +430,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "memchr"
@@ -395,9 +454,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -490,21 +549,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "plotters"
@@ -541,43 +594,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -636,24 +665,24 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -665,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -686,9 +715,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 
 [[package]]
 name = "serde_cbor"
@@ -702,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -713,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -724,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.17"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap",
  "itoa",
@@ -743,22 +772,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -788,9 +808,9 @@ checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-width"
@@ -800,24 +820,23 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -829,9 +848,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -839,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
@@ -854,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -864,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -877,15 +896,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -924,18 +943,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -948,42 +967,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,19 +204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,8 +237,6 @@ dependencies = [
  "atomic",
  "clap 4.1.4",
  "criterion",
- "dashmap",
- "fxhash",
  "num",
  "rand",
  "rayon",
@@ -270,15 +249,6 @@ name = "fastiron-stats"
 version = "1.0.0"
 dependencies = [
  "csv",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -409,16 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,19 +505,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
-]
 
 [[package]]
 name = "plotters"
@@ -688,15 +635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,12 +734,6 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +210,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +256,8 @@ dependencies = [
  "atomic",
  "clap 4.1.4",
  "criterion",
+ "dashmap",
+ "fxhash",
  "num",
  "rand",
  "rayon",
@@ -249,6 +270,15 @@ name = "fastiron-stats"
 version = "1.0.0"
 dependencies = [
  "csv",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -379,6 +409,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +545,19 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "plotters"
@@ -635,6 +688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +796,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"

--- a/fastiron/Cargo.toml
+++ b/fastiron/Cargo.toml
@@ -13,8 +13,6 @@ rand = {version="0.8.5", features=["small_rng"]}
 tinyvec = {version="1.6.0"}
 rayon= {version="1.7.0"}
 atomic = {version="0.5"}
-dashmap = {version="5.4.0"}
-fxhash = {version="0.2.1"}
 
 [dev-dependencies]
 criterion = {version="0.3.4", features=["html_reports"]}

--- a/fastiron/Cargo.toml
+++ b/fastiron/Cargo.toml
@@ -13,6 +13,8 @@ rand = {version="0.8.5", features=["small_rng"]}
 tinyvec = {version="1.6.0"}
 rayon= {version="1.7.0"}
 atomic = {version="0.5"}
+dashmap = {version="5.4.0"}
+fxhash = {version="0.2.1"}
 
 [dev-dependencies]
 criterion = {version="0.3.4", features=["html_reports"]}

--- a/fastiron/src/geometry/mc_cell_state.rs
+++ b/fastiron/src/geometry/mc_cell_state.rs
@@ -1,7 +1,5 @@
 //! Contains code to represent a cell's current state.
 
-use atomic::Atomic;
-
 use crate::constants::CustomFloat;
 
 /// Structure used to represent a cell's state, i.e.
@@ -13,8 +11,6 @@ use crate::constants::CustomFloat;
 pub struct MCCellState<T: CustomFloat> {
     /// Global id of the material the cell is made of.
     pub material: usize,
-    /// Cache for the total cross-sections of energy groups.
-    pub total: Vec<Atomic<T>>,
     /// Cell volume in cm³.
     pub volume: T,
     /// Density of the material in the cell?

--- a/fastiron/src/geometry/mc_domain.rs
+++ b/fastiron/src/geometry/mc_domain.rs
@@ -4,7 +4,6 @@
 
 use std::collections::HashMap;
 
-use atomic::Atomic;
 use num::{one, zero, FromPrimitive};
 
 use crate::{
@@ -171,17 +170,12 @@ impl<T: CustomFloat> MCDomain<T> {
             mesh,
         };
 
-        let num_energy_groups: usize = params.simulation_params.n_groups;
-
         (0..mcdomain.cell_state.len()).for_each(|ii| {
             mcdomain.cell_state[ii].volume = mcdomain.cell_volume(ii);
 
             let rr = cell_position_3dg(&mcdomain.mesh, ii);
             let mat_name = Self::find_material(&params.geometry_params, &rr);
             mcdomain.cell_state[ii].material = mat_db.find_material(&mat_name).unwrap();
-            mcdomain.cell_state[ii].total = (0..num_energy_groups)
-                .map(|_| Atomic::new(zero()))
-                .collect();
 
             mcdomain.cell_state[ii].cell_number_density = one();
 
@@ -191,15 +185,6 @@ impl<T: CustomFloat> MCDomain<T> {
         });
 
         mcdomain
-    }
-
-    /// Clears the cross section cache for future uses.
-    pub fn clear_cross_section_cache(&mut self) {
-        self.cell_state.iter_mut().for_each(|cs| {
-            cs.total
-                .iter_mut()
-                .for_each(|val| *val = Atomic::new(zero()))
-        })
     }
 
     fn find_material(geometry_params: &[GeometryParameters<T>], rr: &MCVector<T>) -> String {

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -22,6 +22,7 @@ use crate::{
         mc_rng_state::rng_sample,
     },
 };
+use dashmap::DashMap;
 use num::{one, zero, Float, FromPrimitive};
 
 /// Creates a [MonteCarloData] object using the specified parameters.
@@ -94,6 +95,7 @@ pub fn init_mcunits<T: CustomFloat>(mcdata: &MonteCarloData<T>) -> Vec<MonteCarl
             let mut mcunit = MonteCarloUnit::new(&mcdata.params);
             init_mesh(&mut mcunit, mcdata);
             init_tallies(&mut mcunit, &mcdata.params);
+            init_xs_cache(&mut mcunit);
             units.push(mcunit);
         }
         ExecPolicy::Distributed | ExecPolicy::Hybrid => todo!(),
@@ -303,6 +305,13 @@ fn init_tallies<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>, params: &Paramet
         params.simulation_params.n_groups,
         params.simulation_params.coral_benchmark,
     )
+}
+
+fn init_xs_cache<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>) {
+    // compute needed capacity
+    let capacity = mcunit.domain.iter().map(|dom| dom.cell_state.len()).sum();
+    // need to add the custom hasher from fxhash
+    mcunit.xs_cache = DashMap::with_capacity(capacity)
 }
 
 #[derive(Debug, Clone, Default)]

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -23,8 +23,8 @@ use crate::{
     },
 };
 use atomic::Atomic;
-use dashmap::DashMap;
-use fxhash::FxBuildHasher;
+//use dashmap::DashMap;
+//use fxhash::FxBuildHasher;
 use num::{one, zero, Float, FromPrimitive};
 
 /// Creates a [MonteCarloData] object using the specified parameters.
@@ -323,7 +323,7 @@ fn init_xs_cache<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>, n_energy_groups
         .map(|dom| {
             dom.cell_state
                 .iter()
-                .map(|cell| (0..n_energy_groups).map(|_| Atomic::new(zero())).collect())
+                .map(|_| (0..n_energy_groups).map(|_| Atomic::new(zero())).collect())
                 .collect()
         })
         .collect();

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -309,9 +309,8 @@ fn init_tallies<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>, params: &Paramet
 }
 
 fn init_xs_cache<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>) {
-    // compute needed capacity
+    // compute needed capacity & init accordingly
     let capacity: usize = mcunit.domain.iter().map(|dom| dom.cell_state.len()).sum();
-    // need to add the custom hasher from fxhash
     mcunit.xs_cache = DashMap::<(usize, usize, usize), T, FxBuildHasher>::with_capacity_and_hasher(
         capacity,
         FxBuildHasher::default(),

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -23,8 +23,6 @@ use crate::{
     },
 };
 use atomic::Atomic;
-//use dashmap::DashMap;
-//use fxhash::FxBuildHasher;
 use num::{one, zero, Float, FromPrimitive};
 
 /// Creates a [MonteCarloData] object using the specified parameters.
@@ -310,13 +308,6 @@ fn init_tallies<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>, params: &Paramet
 }
 
 fn init_xs_cache<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>, n_energy_groups: usize) {
-    // compute needed capacity & init accordingly
-    // need to multiply this by n energy groups
-    /*let capacity: usize = mcunit.domain.iter().map(|dom| dom.cell_state.len()).sum();
-    mcunit.xs_cache = DashMap::<(usize, usize, usize), T, FxBuildHasher>::with_capacity_and_hasher(
-        capacity,
-        FxBuildHasher::default(),
-    );*/
     mcunit.xs_cache.cache = mcunit
         .domain
         .iter()

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -23,6 +23,7 @@ use crate::{
     },
 };
 use dashmap::DashMap;
+use fxhash::FxBuildHasher;
 use num::{one, zero, Float, FromPrimitive};
 
 /// Creates a [MonteCarloData] object using the specified parameters.
@@ -309,9 +310,12 @@ fn init_tallies<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>, params: &Paramet
 
 fn init_xs_cache<T: CustomFloat>(mcunit: &mut MonteCarloUnit<T>) {
     // compute needed capacity
-    let capacity = mcunit.domain.iter().map(|dom| dom.cell_state.len()).sum();
+    let capacity: usize = mcunit.domain.iter().map(|dom| dom.cell_state.len()).sum();
     // need to add the custom hasher from fxhash
-    mcunit.xs_cache = DashMap::with_capacity(capacity)
+    mcunit.xs_cache = DashMap::<(usize, usize, usize), T, FxBuildHasher>::with_capacity_and_hasher(
+        capacity,
+        FxBuildHasher::default(),
+    );
 }
 
 #[derive(Debug, Clone, Default)]

--- a/fastiron/src/montecarlo.rs
+++ b/fastiron/src/montecarlo.rs
@@ -8,8 +8,8 @@ use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 
 use atomic::Atomic;
-use dashmap::DashMap;
-use fxhash::FxBuildHasher;
+//use dashmap::DashMap;
+//use fxhash::FxBuildHasher;
 use num::zero;
 
 use crate::constants::CustomFloat;
@@ -134,6 +134,7 @@ pub struct XSCache<T: CustomFloat> {
     pub cache: Vec<Vec<Vec<Atomic<T>>>>,
 }
 
+// maybe make theses accesses unchecked?
 impl<T: CustomFloat> Index<(usize, usize, usize)> for XSCache<T> {
     type Output = Atomic<T>;
 

--- a/fastiron/src/montecarlo.rs
+++ b/fastiron/src/montecarlo.rs
@@ -8,8 +8,6 @@ use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 
 use atomic::Atomic;
-//use dashmap::DashMap;
-//use fxhash::FxBuildHasher;
 use num::zero;
 
 use crate::constants::CustomFloat;
@@ -70,7 +68,6 @@ pub struct MonteCarloUnit<T: CustomFloat> {
     pub unit_weight: T,
     /// HashMap used to lazily compute cross-sections.
     pub xs_cache: XSCache<T>,
-    //pub xs_cache: DashMap<(usize, usize, usize), T, FxBuildHasher>,
 }
 
 impl<T: CustomFloat> MonteCarloUnit<T> {
@@ -88,13 +85,11 @@ impl<T: CustomFloat> MonteCarloUnit<T> {
             fast_timer,
             unit_weight: zero(),
             xs_cache: Default::default(),
-            //xs_cache: DashMap::default(),
         }
     }
 
     /// Clear the cross section cache for each domain.
     pub fn clear_cross_section_cache(&mut self) {
-        //self.xs_cache.clear();
         self.xs_cache.cache.iter_mut().for_each(|domain| {
             domain
                 .iter_mut()

--- a/fastiron/src/montecarlo.rs
+++ b/fastiron/src/montecarlo.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Debug;
 
+use dashmap::DashMap;
 use num::zero;
 
 use crate::constants::CustomFloat;
@@ -62,8 +63,10 @@ pub struct MonteCarloUnit<T: CustomFloat> {
     pub tallies: Tallies<T>,
     /// Object storing all tallies of the simulation.
     pub fast_timer: MCFastTimerContainer,
-    /// Weight of the particles at creation in a source zone
+    /// Weight of the particles at creation in a source zone.
     pub unit_weight: T,
+    /// HashMap used to lazily compute cross-sections.
+    pub xs_map: DashMap<(usize, usize, usize), T>,
 }
 
 impl<T: CustomFloat> MonteCarloUnit<T> {
@@ -80,6 +83,7 @@ impl<T: CustomFloat> MonteCarloUnit<T> {
             tallies,
             fast_timer,
             unit_weight: zero(),
+            xs_map: DashMap::default(),
         }
     }
 

--- a/fastiron/src/montecarlo.rs
+++ b/fastiron/src/montecarlo.rs
@@ -7,6 +7,7 @@
 use std::fmt::Debug;
 
 use dashmap::DashMap;
+use fxhash::FxBuildHasher;
 use num::zero;
 
 use crate::constants::CustomFloat;
@@ -67,7 +68,7 @@ pub struct MonteCarloUnit<T: CustomFloat> {
     /// Weight of the particles at creation in a source zone.
     pub unit_weight: T,
     /// HashMap used to lazily compute cross-sections.
-    pub xs_cache: DashMap<(usize, usize, usize), T>,
+    pub xs_cache: DashMap<(usize, usize, usize), T, FxBuildHasher>,
 }
 
 impl<T: CustomFloat> MonteCarloUnit<T> {
@@ -84,7 +85,7 @@ impl<T: CustomFloat> MonteCarloUnit<T> {
             tallies,
             fast_timer,
             unit_weight: zero(),
-            xs_cache: DashMap::default(),
+            xs_cache: DashMap::<(usize, usize, usize), T, FxBuildHasher>::default(),
         }
     }
 

--- a/fastiron/src/simulation/mc_segment_outcome.rs
+++ b/fastiron/src/simulation/mc_segment_outcome.rs
@@ -119,6 +119,11 @@ pub fn outcome<T: CustomFloat>(
 
     // get cross section
     // lazily computed
+    let macroscopic_total_xsection = mcunit.get_cross_section(
+        (particle.domain, particle.cell, particle.energy_group),
+        mcdata,
+    );
+    /*
     let precomputed_cross_section = mcunit.domain[particle.domain].cell_state[particle.cell].total
         [particle.energy_group]
         .load(Ordering::Relaxed);
@@ -143,7 +148,7 @@ pub fn outcome<T: CustomFloat>(
 
         tmp
     };
-
+    */
     // always computed
     /*
     let mat_gid: usize = mcunit.domain[particle.domain].cell_state[particle.cell].material;

--- a/fastiron/src/simulation/mc_segment_outcome.rs
+++ b/fastiron/src/simulation/mc_segment_outcome.rs
@@ -11,7 +11,6 @@
 
 use std::fmt::Debug;
 
-use atomic::Ordering;
 use num::{one, zero};
 
 use crate::{
@@ -20,7 +19,7 @@ use crate::{
     geometry::facets::MCNearestFacet,
     montecarlo::{MonteCarloData, MonteCarloUnit},
     particles::mc_particle::MCParticle,
-    simulation::{macro_cross_section::weighted_macroscopic_cross_section, mct::nearest_facet},
+    simulation::mct::nearest_facet,
 };
 
 /// Enum representing the outcome of the current segment.
@@ -123,32 +122,6 @@ pub fn outcome<T: CustomFloat>(
         (particle.domain, particle.cell, particle.energy_group),
         mcdata,
     );
-    /*
-    let precomputed_cross_section = mcunit.domain[particle.domain].cell_state[particle.cell].total
-        [particle.energy_group]
-        .load(Ordering::Relaxed);
-    let macroscopic_total_xsection = if precomputed_cross_section > zero() {
-        // XS was already cached
-        precomputed_cross_section
-    } else {
-        // compute XS
-        let mat_gid: usize = mcunit.domain[particle.domain].cell_state[particle.cell].material;
-        let cell_nb_density: T =
-            mcunit.domain[particle.domain].cell_state[particle.cell].cell_number_density;
-
-        let tmp = weighted_macroscopic_cross_section(
-            mcdata,
-            mat_gid,
-            cell_nb_density,
-            particle.energy_group,
-        );
-        // cache the XS
-        mcunit.domain[particle.domain].cell_state[particle.cell].total[particle.energy_group]
-            .store(tmp, Ordering::Relaxed);
-
-        tmp
-    };
-    */
     // always computed
     /*
     let mat_gid: usize = mcunit.domain[particle.domain].cell_state[particle.cell].material;

--- a/fastiron/src/simulation/mc_segment_outcome.rs
+++ b/fastiron/src/simulation/mc_segment_outcome.rs
@@ -119,21 +119,6 @@ pub fn outcome<T: CustomFloat>(
 
     // get cross section
     // lazily computed
-    /*
-    let macroscopic_total_xsection = *mcunit
-        .xs_cache
-        .entry((particle.domain, particle.cell, particle.energy_group))
-        .or_insert_with(|| {
-            let mat_gid: usize = mcunit.domain[particle.domain].cell_state[particle.cell].material;
-            let cell_nb_density: T =
-                mcunit.domain[particle.domain].cell_state[particle.cell].cell_number_density;
-            weighted_macroscopic_cross_section(
-                mcdata,
-                mat_gid,
-                cell_nb_density,
-                particle.energy_group,
-            )
-        });*/
     // This ordering should make it so that we dont compute a XS multiple times?
     let pcxs = mcunit.xs_cache[(particle.domain, particle.cell, particle.energy_group)]
         .load(Ordering::Acquire);

--- a/fastiron/src/simulation/mc_segment_outcome.rs
+++ b/fastiron/src/simulation/mc_segment_outcome.rs
@@ -134,8 +134,9 @@ pub fn outcome<T: CustomFloat>(
                 particle.energy_group,
             )
         });*/
+    // This ordering should make it so that we dont compute a XS multiple times?
     let pcxs = mcunit.xs_cache[(particle.domain, particle.cell, particle.energy_group)]
-        .load(Ordering::Relaxed);
+        .load(Ordering::Acquire);
     let macroscopic_total_xsection = if pcxs > zero() {
         // use precomputed value
         pcxs
@@ -151,17 +152,9 @@ pub fn outcome<T: CustomFloat>(
             particle.energy_group,
         );
         mcunit.xs_cache[(particle.domain, particle.cell, particle.energy_group)]
-            .store(tmp, Ordering::Relaxed);
+            .store(tmp, Ordering::Release);
         tmp
     };
-    // always computed
-    /*
-    let mat_gid: usize = mcunit.domain[particle.domain].cell_state[particle.cell].material;
-    let cell_nb_density: T =
-        mcunit.domain[particle.domain].cell_state[particle.cell].cell_number_density;
-    let macroscopic_total_xsection =
-        weighted_macroscopic_cross_section(mcdata, mat_gid, cell_nb_density, particle.energy_group);
-    */
 
     // prepare particle
     particle.total_cross_section = macroscopic_total_xsection;


### PR DESCRIPTION
Changed how cross-section cacheing is handled. The following were tested:

- Base method: XS is stored in with the mesh data.
- Thread-safe hashmap (base algorithm & fxhash) using the domain, cell & energy group as key.
- Nested vectors with the same length/depth as the mesh data.

Nested vectors were kept for the final implem.