### PR TITLE
Simpler tallies

### DIFF
--- a/fastiron/src/data/tallies.rs
+++ b/fastiron/src/data/tallies.rs
@@ -246,7 +246,7 @@ impl<T: CustomFloat> Tallies<T> {
 
         // Initialize Fluence if necessary
         if bench_type != BenchType::Standard {
-            self.fluence.cell = vec![zero(); self.scalar_flux_domain.cell.len()];
+            self.fluence.cell = vec![zero(); n_cells];
         }
     }
 

--- a/fastiron/src/data/tallies.rs
+++ b/fastiron/src/data/tallies.rs
@@ -20,7 +20,6 @@ use num::zero;
 
 use crate::{
     constants::CustomFloat,
-    parameters::BenchType,
     utils::mc_fast_timer::{self, MCFastTimerContainer, Section},
 };
 
@@ -211,24 +210,12 @@ pub struct Tallies<T: CustomFloat> {
     pub balance_cycle: Balance,
     /// Top-level structure holding scalar flux data.
     pub scalar_flux_domain: ScalarFluxDomain<T>,
-    /// Top-level structure used to compute fluence data.
-    pub fluence: FluenceDomain<T>,
 }
 
 impl<T: CustomFloat> Tallies<T> {
     /// Prepare the tallies for use.
-    pub fn initialize_tallies(
-        &mut self,
-        n_cells: usize,
-        num_energy_groups: usize,
-        bench_type: BenchType,
-    ) {
+    pub fn initialize_tallies(&mut self, n_cells: usize, num_energy_groups: usize) {
         self.scalar_flux_domain = ScalarFluxDomain::new(n_cells, num_energy_groups);
-
-        // Initialize Fluence if necessary
-        if bench_type != BenchType::Standard {
-            self.fluence.cell = vec![zero(); n_cells];
-        }
     }
 
     /// Prints summarized data recorded by the tallies.

--- a/fastiron/src/data/tallies.rs
+++ b/fastiron/src/data/tallies.rs
@@ -192,38 +192,6 @@ impl<T: CustomFloat> ScalarFluxDomain<T> {
     }
 }
 
-//================
-// Cell tally data
-//================
-
-/// Domain-specific _cell-tallied-data-holding_ sub-structure.
-#[derive(Debug, Default, Clone)]
-pub struct CellTallyDomain<T: CustomFloat> {
-    pub cell: Vec<T>,
-}
-
-impl<T: CustomFloat> CellTallyDomain<T> {
-    /// Constructor.
-    pub fn new(domain: &MCDomain<T>) -> Self {
-        Self {
-            cell: vec![zero(); domain.cell_state.len()],
-        }
-    }
-
-    /// Reset fields to their default value i.e. 0.
-    pub fn reset(&mut self) {
-        self.cell = vec![zero(); self.cell.len()];
-    }
-
-    /// Add another [CellTallyDomain]'s value to its own.
-    pub fn add(&mut self, other: &CellTallyDomain<T>) {
-        // zip iterators from the two objects' values.
-        let iter = zip(self.cell.iter_mut(), other.cell.iter());
-        // sum other to self
-        iter.for_each(|(lhs, rhs)| *lhs += *rhs);
-    }
-}
-
 //========
 // Tallies
 //========
@@ -237,8 +205,6 @@ pub struct Tallies<T: CustomFloat> {
     pub balance_cycle: Balance,
     /// Top-level structure holding scalar flux data.
     pub scalar_flux_domain: ScalarFluxDomain<T>,
-    /// Top-level structure holding cell tallied data.
-    pub cell_tally_domain: CellTallyDomain<T>,
     /// Top-level structure used to compute fluence data.
     pub fluence: FluenceDomain<T>,
     /// Energy spectrum of the problem.
@@ -253,7 +219,6 @@ impl<T: CustomFloat> Tallies<T> {
             balance_cumulative: Default::default(),
             balance_cycle: Default::default(),
             scalar_flux_domain: Default::default(),
-            cell_tally_domain: Default::default(),
             fluence: Default::default(),
             spectrum,
         }
@@ -266,7 +231,6 @@ impl<T: CustomFloat> Tallies<T> {
         num_energy_groups: usize,
         bench_type: BenchType,
     ) {
-        self.cell_tally_domain = CellTallyDomain::new(domain);
         self.scalar_flux_domain = ScalarFluxDomain::new(domain, num_energy_groups);
 
         // Initialize Fluence if necessary
@@ -432,7 +396,6 @@ impl<T: CustomFloat> Tallies<T> {
             self.fluence.compute(&self.scalar_flux_domain);
         }
 
-        self.cell_tally_domain.reset();
         self.scalar_flux_domain.reset();
     }
 }

--- a/fastiron/src/data/tallies.rs
+++ b/fastiron/src/data/tallies.rs
@@ -20,7 +20,6 @@ use num::zero;
 
 use crate::{
     constants::CustomFloat,
-    geometry::mc_domain::MCDomain,
     parameters::BenchType,
     particles::{particle_collection::ParticleCollection, particle_container::ParticleContainer},
     utils::mc_fast_timer::{self, MCFastTimerContainer, Section},
@@ -173,9 +172,9 @@ pub struct ScalarFluxDomain<T: CustomFloat> {
 
 impl<T: CustomFloat> ScalarFluxDomain<T> {
     /// Constructor.
-    pub fn new(domain: &MCDomain<T>, num_groups: usize) -> Self {
+    pub fn new(n_cells: usize, num_groups: usize) -> Self {
         // originally uses BulkStorage object for contiguous memory
-        let cell = (0..domain.cell_state.len() * num_groups)
+        let cell = (0..n_cells * num_groups)
             .map(|_| Atomic::new(zero()))
             .collect();
         Self { num_groups, cell }
@@ -239,11 +238,11 @@ impl<T: CustomFloat> Tallies<T> {
     /// Prepare the tallies for use.
     pub fn initialize_tallies(
         &mut self,
-        domain: &MCDomain<T>,
+        n_cells: usize,
         num_energy_groups: usize,
         bench_type: BenchType,
     ) {
-        self.scalar_flux_domain = ScalarFluxDomain::new(domain, num_energy_groups);
+        self.scalar_flux_domain = ScalarFluxDomain::new(n_cells, num_energy_groups);
 
         // Initialize Fluence if necessary
         if bench_type != BenchType::Standard {

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -303,7 +303,7 @@ fn init_mesh<T: CustomFloat>(mcunits: &mut [MonteCarloUnit<T>], mcdata: &MonteCa
 fn init_tallies<T: CustomFloat>(mcunits: &mut [MonteCarloUnit<T>], params: &Parameters<T>) {
     mcunits.iter_mut().for_each(|mcunit| {
         mcunit.tallies.initialize_tallies(
-            &mcunit.domain,
+            mcunit.domain.cell_state.len(),
             params.simulation_params.n_groups,
             params.simulation_params.coral_benchmark,
         )

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -301,11 +301,6 @@ fn init_mesh<T: CustomFloat>(mcunits: &mut [MonteCarloUnit<T>], mcdata: &MonteCa
         mcunits[gid].domain =
             MCDomain::new(&comm.partition[gid], &global_grid, &ddc, params, mat_db);
     });
-    //comm.partition.iter().for_each(|mesh_p| {
-    //    mcunit
-    //        .domain
-    //        .push(MCDomain::new(mesh_p, &global_grid, &ddc, params, mat_db))
-    //});
 }
 
 fn init_tallies<T: CustomFloat>(mcunits: &mut [MonteCarloUnit<T>], params: &Parameters<T>) {
@@ -313,7 +308,6 @@ fn init_tallies<T: CustomFloat>(mcunits: &mut [MonteCarloUnit<T>], params: &Para
         mcunit.tallies.initialize_tallies(
             mcunit.domain.cell_state.len(),
             params.simulation_params.n_groups,
-            params.simulation_params.coral_benchmark,
         )
     })
 }

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -12,7 +12,7 @@ use crate::{
     geometry::{
         global_fcc_grid::GlobalFccGrid, mc_domain::MCDomain, mesh_partition::MeshPartition,
     },
-    montecarlo::{MonteCarloData, MonteCarloUnit},
+    montecarlo::{MonteCarloData, MonteCarloResults, MonteCarloUnit},
     parameters::Parameters,
     particles::particle_container::ParticleContainer,
     utils::{
@@ -86,7 +86,7 @@ pub fn init_particle_containers<T: CustomFloat>(
 
 pub fn init_mcunits<T: CustomFloat>(mcdata: &MonteCarloData<T>) -> Vec<MonteCarloUnit<T>> {
     let mut units: Vec<MonteCarloUnit<T>> = (0..mcdata.params.simulation_params.n_units)
-        .map(|_| MonteCarloUnit::new(&mcdata.params))
+        .map(|_| MonteCarloUnit::default())
         .collect();
 
     // inits
@@ -103,6 +103,14 @@ pub fn init_mcunits<T: CustomFloat>(mcdata: &MonteCarloData<T>) -> Vec<MonteCarl
     println!("  [Consistency Check]: Done");
 
     units
+}
+
+pub fn init_results<T: CustomFloat>(params: &Parameters<T>) -> MonteCarloResults<T> {
+    MonteCarloResults::new(
+        params.simulation_params.energy_spectrum.to_owned(),
+        params.simulation_params.n_groups,
+        params.simulation_params.coral_benchmark,
+    )
 }
 
 //==================

--- a/fastiron/src/montecarlo.rs
+++ b/fastiron/src/montecarlo.rs
@@ -132,7 +132,7 @@ pub struct MonteCarloResults<T: CustomFloat> {
     pub fluence: FluenceDomain<T>,
     /// Energy spectrum of the problem.
     pub spectrum: EnergySpectrum,
-    /// Enum used to ...
+    /// Enum used to adapt additional checks after simulation.
     pub bench_type: BenchType,
 }
 

--- a/fastiron/src/montecarlo.rs
+++ b/fastiron/src/montecarlo.rs
@@ -11,11 +11,14 @@ use atomic::{Atomic, Ordering};
 use num::zero;
 
 use crate::constants::CustomFloat;
+use crate::data::energy_spectrum::EnergySpectrum;
 use crate::data::material_database::MaterialDatabase;
 use crate::data::nuclear_data::NuclearData;
-use crate::data::tallies::Tallies;
+use crate::data::tallies::{Balance, FluenceDomain, Tallies};
 use crate::geometry::mc_domain::MCDomain;
-use crate::parameters::Parameters;
+use crate::parameters::{BenchType, Parameters};
+use crate::particles::particle_collection::ParticleCollection;
+use crate::particles::particle_container::ParticleContainer;
 use crate::utils::mc_fast_timer::MCFastTimerContainer;
 use crate::utils::mc_processor_info::MCProcessorInfo;
 
@@ -56,7 +59,7 @@ impl<T: CustomFloat> MonteCarloData<T> {
 
 /// Super-structure used to contain unit-specific data of the Monte-Carlo problem.
 /// The notion of unit is specified ....
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MonteCarloUnit<T: CustomFloat> {
     /// List of spatial domains.
     pub domain: MCDomain<T>,
@@ -71,23 +74,6 @@ pub struct MonteCarloUnit<T: CustomFloat> {
 }
 
 impl<T: CustomFloat> MonteCarloUnit<T> {
-    /// Constructor.
-    pub fn new(params: &Parameters<T>) -> Self {
-        let tallies: Tallies<T> = Tallies::new(
-            params.simulation_params.energy_spectrum.to_owned(),
-            params.simulation_params.n_groups,
-        );
-        let fast_timer: MCFastTimerContainer = MCFastTimerContainer::default();
-
-        Self {
-            domain: Default::default(),
-            tallies,
-            fast_timer,
-            unit_weight: zero(),
-            xs_cache: Default::default(),
-        }
-    }
-
     /// Clear the cross section cache for each domain.
     pub fn clear_cross_section_cache(&mut self) {
         self.xs_cache
@@ -136,5 +122,65 @@ impl<T: CustomFloat> Index<(usize, usize)> for XSCache<T> {
 impl<T: CustomFloat> IndexMut<(usize, usize)> for XSCache<T> {
     fn index_mut(&mut self, index: (usize, usize)) -> &mut Self::Output {
         &mut self.cache[index.0 * self.num_groups + index.1]
+    }
+}
+
+pub struct MonteCarloResults<T: CustomFloat> {
+    /// Balance used for cumulative and centralized statistics.
+    pub balance_cumulative: Balance,
+    /// Top-level structure used to compute fluence data.
+    pub fluence: FluenceDomain<T>,
+    /// Energy spectrum of the problem.
+    pub spectrum: EnergySpectrum,
+    /// Enum used to ...
+    pub bench_type: BenchType,
+}
+
+impl<T: CustomFloat> MonteCarloResults<T> {
+    pub fn new(spectrum_name: String, spectrum_size: usize, bench_type: BenchType) -> Self {
+        Self {
+            balance_cumulative: Default::default(),
+            fluence: Default::default(),
+            spectrum: EnergySpectrum::new(spectrum_name, spectrum_size),
+            bench_type,
+        }
+    }
+
+    /// Update the energy spectrum by going over all the currently valid particles.
+    pub fn update_spectrum(&mut self, containers: &[ParticleContainer<T>]) {
+        if self.spectrum.file_name.is_empty() {
+            return;
+        }
+
+        let update_function = |particle_list: &ParticleCollection<T>, spectrum: &mut [u64]| {
+            particle_list.into_iter().for_each(|particle| {
+                spectrum[particle.energy_group] += 1;
+            });
+        };
+
+        // Iterate on all containers
+        containers.iter().for_each(|container| {
+            // Iterate on processing particles
+            update_function(
+                &container.processing_particles,
+                &mut self.spectrum.census_energy_spectrum,
+            );
+            // Iterate on processed particles
+            update_function(
+                &container.processed_particles,
+                &mut self.spectrum.census_energy_spectrum,
+            );
+        })
+    }
+
+    pub fn update_stats(&mut self, mcunits: &mut [MonteCarloUnit<T>]) {
+        mcunits.iter_mut().for_each(|mcunit| {
+            self.balance_cumulative
+                .add_to_self(&mcunit.tallies.balance_cycle);
+            if self.bench_type != BenchType::Standard {
+                self.fluence.compute(&mcunit.tallies.scalar_flux_domain)
+            }
+            mcunit.tallies.cycle_finalize();
+        })
     }
 }

--- a/fastiron/src/simulation/cycle_tracking.rs
+++ b/fastiron/src/simulation/cycle_tracking.rs
@@ -66,7 +66,7 @@ fn cycle_tracking_function<T: CustomFloat>(
         balance[TalliedEvent::NumSegments] += 1;
         particle.num_segments += one();
         // update scalar flux tally
-        mcunit.tallies.scalar_flux_domain.cell[particle.cell][particle.energy_group]
+        mcunit.tallies.scalar_flux_domain[(particle.cell, particle.energy_group)]
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
                 Some(x + particle.segment_path_length * particle.weight)
             })


### PR DESCRIPTION
- Removed dead code from the `Tallies` structure
- Extracted non-cyclic structure from the tallies to put them in the new structure `MonteCarloResults`
- Flattened the scalar flux data (~5% perf difference)