### PR TITLE
Faster init

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "num 0.4.0",
  "rand",
  "rayon",
+ "rustc-hash",
  "serde_yaml",
  "tinyvec",
 ]
@@ -732,6 +733,12 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"

--- a/fastiron/Cargo.toml
+++ b/fastiron/Cargo.toml
@@ -15,6 +15,7 @@ rayon= {version="1.7.0"}
 atomic = {version="0.5"}
 hwloc2 = {version="2.2.0"}
 libc = {version="0.2.146"}
+rustc-hash = {version="1.1.0"}
 
 [dev-dependencies]
 criterion = {version="0.3.4", features=["html_reports"]}

--- a/fastiron/src/data/nuclear_data.rs
+++ b/fastiron/src/data/nuclear_data.rs
@@ -2,9 +2,8 @@
 //!
 //! This module contains code used to store, model and compute nuclear data and quantities.
 
-use std::collections::HashMap;
-
 use num::{zero, FromPrimitive};
+use rustc_hash::FxHashMap;
 
 use crate::{constants::CustomFloat, parameters::MaterialParameters};
 
@@ -185,7 +184,7 @@ impl<T: CustomFloat> NuclearData<T> {
     /// specified in the material.
     pub fn add_isotope(
         &mut self,
-        cross_section: &HashMap<String, Polynomial<T>>,
+        cross_section: &FxHashMap<String, Polynomial<T>>,
         mp: &MaterialParameters<T>,
         nu_bar: T,
     ) -> usize {

--- a/fastiron/src/geometry/facets.rs
+++ b/fastiron/src/geometry/facets.rs
@@ -29,8 +29,12 @@ pub struct MCGeneralPlane<T: CustomFloat> {
 impl<T: CustomFloat> MCGeneralPlane<T> {
     /// Constructor. This creates an object corresponding to the plane formed by the
     /// three points passed as arguments.
-    pub fn new(r0: &MCVector<T>, r1: &MCVector<T>, r2: &MCVector<T>) -> Self {
+    pub fn new(points: &[MCVector<T>]) -> Self {
         let one: T = one();
+        assert_eq!(points.len(), 3);
+        let r0 = points[0];
+        let r1 = points[1];
+        let r2 = points[2];
 
         let mut a = ((r1.y - r0.y) * (r2.z - r0.z)) - ((r1.z - r0.z) * (r2.y - r0.y));
         let mut b = ((r1.z - r0.z) * (r2.x - r0.x)) - ((r1.x - r0.x) * (r2.z - r0.z));
@@ -115,7 +119,7 @@ pub enum MCSubfacetAdjacencyEvent {
 ///
 /// This structure is _oriented_, i.e. there is a current cell and a neighbor
 /// cell.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct SubfacetAdjacency {
     /// Event associated with the facet junction.
     pub event: MCSubfacetAdjacencyEvent,
@@ -132,7 +136,7 @@ pub struct SubfacetAdjacency {
 }
 
 /// Structure for adjacent facet representation.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct MCFacetAdjacency {
     /// Adjacency data.
     pub subfacet: SubfacetAdjacency,
@@ -146,4 +150,16 @@ pub struct MCFacetAdjacency {
 pub struct MCFacetAdjacencyCell {
     pub facet: [MCFacetAdjacency; N_FACETS_OUT],
     pub point: [usize; N_POINTS_INTERSEC],
+}
+
+impl MCFacetAdjacencyCell {
+    pub fn get_planes<T: CustomFloat>(
+        &self,
+        node: &[MCVector<T>],
+    ) -> [MCGeneralPlane<T>; N_FACETS_OUT] {
+        self.facet.map(|facet_adjacency| {
+            let points = facet_adjacency.point.map(|idx| node[idx]);
+            MCGeneralPlane::new(&points)
+        })
+    }
 }

--- a/fastiron/src/geometry/mc_domain.rs
+++ b/fastiron/src/geometry/mc_domain.rs
@@ -2,9 +2,8 @@
 //!
 //!
 
-use std::collections::HashMap;
-
 use num::{one, zero, FromPrimitive};
+use rustc_hash::FxHashMap;
 
 use crate::{
     constants::CustomFloat,
@@ -270,11 +269,11 @@ impl<T: CustomFloat> MCDomain<T> {
 fn bootstrap_node_map<T: CustomFloat>(
     partition: &MeshPartition,
     grid: &GlobalFccGrid<T>,
-) -> HashMap<usize, usize> {
+) -> FxHashMap<usize, usize> {
     // res
-    let mut node_idx_map: HashMap<usize, usize> = Default::default();
+    let mut node_idx_map: FxHashMap<usize, usize> = Default::default();
     // intermediate struct
-    let mut face_centers: HashMap<usize, usize> = Default::default();
+    let mut face_centers: FxHashMap<usize, usize> = Default::default();
 
     for (k, v) in &partition.cell_info_map {
         // only process partition of our domain
@@ -306,14 +305,14 @@ fn bootstrap_node_map<T: CustomFloat>(
 
 /// Build the cells object of the mesh.
 fn build_cells<T: CustomFloat>(
-    node_idx_map: &HashMap<usize, usize>,
+    node_idx_map: &FxHashMap<usize, usize>,
     nbr_domain: &[usize],
     partition: &MeshPartition,
     grid: &GlobalFccGrid<T>,
     boundary_cond: &[MCSubfacetAdjacencyEvent],
 ) -> Vec<MCFacetAdjacencyCell> {
     // nbr_domain_idx[domain_gid] = local_nbr_idx
-    let mut nbr_domain_idx: HashMap<usize, Option<usize>> = Default::default();
+    let mut nbr_domain_idx: FxHashMap<usize, Option<usize>> = Default::default();
     (0..nbr_domain.len()).for_each(|ii| {
         nbr_domain_idx.insert(nbr_domain[ii], Some(ii));
     });

--- a/fastiron/src/geometry/mc_domain.rs
+++ b/fastiron/src/geometry/mc_domain.rs
@@ -91,7 +91,7 @@ impl<T: CustomFloat> MCMeshDomain<T> {
         boundary_condition: &[MCSubfacetAdjacencyEvent],
     ) -> Self {
         // nbr_domain_gid
-        let nbr_domain_gid: Vec<usize> = mesh_partition.nbr_domains.clone();
+        let nbr_domain_gid: Vec<usize> = mesh_partition.nbr_domains.iter().copied().collect();
 
         // nbr_rank
         let mut nbr_rank: Vec<usize> = Vec::with_capacity(nbr_domain_gid.len());

--- a/fastiron/src/geometry/mc_domain.rs
+++ b/fastiron/src/geometry/mc_domain.rs
@@ -91,7 +91,7 @@ impl<T: CustomFloat> MCMeshDomain<T> {
         boundary_condition: &[MCSubfacetAdjacencyEvent],
     ) -> Self {
         // nbr_domain_gid
-        let nbr_domain_gid: Vec<usize> = mesh_partition.nbr_domains.iter().copied().collect();
+        let nbr_domain_gid: Vec<usize> = mesh_partition.nbr_domains.clone();
 
         // nbr_rank
         let mut nbr_rank: Vec<usize> = Vec::with_capacity(nbr_domain_gid.len());

--- a/fastiron/src/geometry/mesh_partition.rs
+++ b/fastiron/src/geometry/mesh_partition.rs
@@ -2,7 +2,9 @@
 //!
 //!
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashMap;
 
 use crate::{
     constants::{CustomFloat, Tuple3},
@@ -11,7 +13,7 @@ use crate::{
 
 use super::{global_fcc_grid::GlobalFccGrid, grid_assignment_object::GridAssignmentObject};
 
-type MapType = HashMap<usize, CellInfo>;
+type MapType = FxHashMap<usize, CellInfo>;
 
 /// Structure used to hold cell information.
 #[derive(Debug, Clone, Copy, Default)]

--- a/fastiron/src/geometry/mesh_partition.rs
+++ b/fastiron/src/geometry/mesh_partition.rs
@@ -150,23 +150,54 @@ impl MeshPartition {
         wet_cells: &mut Vec<usize>,
     ) {
         let tt: Tuple3 = grid.cell_idx_to_tuple(cell_idx);
+        const NBR_COORDS: [(i32, i32, i32); 26] = [
+            // (-1, x, y)
+            (-1, -1, -1),
+            (-1, -1, 0),
+            (-1, -1, 1),
+            (-1, 0, -1),
+            (-1, 0, 0),
+            (-1, 0, 1),
+            (-1, 1, -1),
+            (-1, 1, 0),
+            (-1, 1, 1),
+            // (0, x, y) except (0, 0, 0)
+            (0, -1, -1),
+            (0, -1, 0),
+            (0, -1, 1),
+            (0, 0, -1),
+            (0, 0, 1),
+            (0, 1, -1),
+            (0, 1, 0),
+            (0, 1, 1),
+            // (1, x, y)
+            (1, -1, -1),
+            (1, -1, 0),
+            (1, -1, 1),
+            (1, 0, -1),
+            (1, 0, 0),
+            (1, 0, 1),
+            (1, 1, -1),
+            (1, 1, 0),
+            (1, 1, 1),
+        ];
 
-        (-1..2).for_each(|ii: i32| {
-            (-1..2).for_each(|jj: i32| {
-                (-1..2).for_each(|kk: i32| {
-                    if (ii == 0) & (jj == 0) & (kk == 0) {
-                        return;
-                    }
-                    let nbr_tuple = (tt.0 as i32 + ii, tt.1 as i32 + jj, tt.2 as i32 + kk);
-                    let snaped_nbr_tuple = grid.snap_turtle(nbr_tuple);
-                    let nbr_idx = grid.cell_tuple_to_idx(&snaped_nbr_tuple);
-                    if !wet_cells.contains(&nbr_idx) {
-                        flood_queue.push_back(nbr_idx);
-                        wet_cells.push(nbr_idx);
-                    }
-                });
+        NBR_COORDS
+            .iter()
+            .map(|offset| {
+                let snaped = grid.snap_turtle((
+                    tt.0 as i32 + offset.0,
+                    tt.1 as i32 + offset.1,
+                    tt.2 as i32 + offset.2,
+                ));
+                grid.cell_tuple_to_idx(&snaped)
+            })
+            .for_each(|nbr_idx| {
+                if !wet_cells.contains(&nbr_idx) {
+                    flood_queue.push_back(nbr_idx);
+                    wet_cells.push(nbr_idx);
+                }
             });
-        });
     }
 }
 

--- a/fastiron/src/geometry/mesh_partition.rs
+++ b/fastiron/src/geometry/mesh_partition.rs
@@ -4,7 +4,7 @@
 
 use std::collections::VecDeque;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use crate::{
     constants::{CustomFloat, Tuple3},
@@ -39,8 +39,8 @@ pub struct MeshPartition {
     pub foreman: usize,
     /// Map linking cell global identifier to their [CellInfo] structure
     pub cell_info_map: MapType,
-    /// List of neighboring domain identifiers. **Should be replaced by a set**.
-    pub nbr_domains: FxHashSet<usize>,
+    /// List of neighboring domain identifiers.
+    pub nbr_domains: Vec<usize>,
 }
 
 impl MeshPartition {
@@ -59,7 +59,7 @@ impl MeshPartition {
         &mut self,
         grid: &GlobalFccGrid<T>,
         centers: &[MCVector<T>],
-    ) -> FxHashSet<(usize, usize)> {
+    ) -> Vec<(usize, usize)> {
         self.assign_cells_to_domain(centers, grid);
 
         self.build_cell_idx_map(grid)
@@ -95,9 +95,9 @@ impl MeshPartition {
             if domain == self.domain_gid {
                 // if current cell is in domain, check neighbor
                 Self::add_nbrs_to_flood(cell_idx, grid, &mut flood_queue, &mut wet_cells);
-            } else {
+            } else if !self.nbr_domains.contains(&domain) {
                 // else, keep track of neighbor domains
-                self.nbr_domains.insert(domain);
+                self.nbr_domains.push(domain);
             }
         }
     }
@@ -105,8 +105,8 @@ impl MeshPartition {
     fn build_cell_idx_map<T: CustomFloat>(
         &mut self,
         grid: &GlobalFccGrid<T>,
-    ) -> FxHashSet<(usize, usize)> {
-        let mut remote_cells: FxHashSet<(usize, usize)> = Default::default();
+    ) -> Vec<(usize, usize)> {
+        let mut remote_cells: Vec<(usize, usize)> = Default::default();
 
         let mut n_local_cells: usize = 0;
 
@@ -129,7 +129,9 @@ impl MeshPartition {
                             continue;
                         }
                         // replace the update to sendSet
-                        remote_cells.insert((domain_gid, j_cell_gid));
+                        if !remote_cells.contains(&(domain_gid, j_cell_gid)) {
+                            remote_cells.push((domain_gid, j_cell_gid));
+                        }
                     }
                 }
             }

--- a/fastiron/src/init.rs
+++ b/fastiron/src/init.rs
@@ -1,6 +1,6 @@
 //! Initialization code for the problem
 
-use std::{collections::HashMap, fmt::Debug, fs::File, io::Write};
+use std::{fmt::Debug, fs::File, io::Write};
 
 use crate::{
     constants::{CustomFloat, Tuple3},
@@ -24,6 +24,7 @@ use crate::{
 };
 use atomic::Atomic;
 use num::{one, zero, Float, FromPrimitive};
+use rustc_hash::FxHashMap;
 
 /// Creates a [MonteCarloData] object using the specified parameters.
 pub fn init_mcdata<T: CustomFloat>(params: Parameters<T>) -> MonteCarloData<T> {
@@ -128,7 +129,7 @@ fn init_nuclear_data<T: CustomFloat>(mcdata: &mut MonteCarloData<T>) {
     mcdata.nuclear_data =
         NuclearData::new(params.simulation_params.n_groups, energy_low, energy_high);
 
-    let mut cross_section: HashMap<String, Polynomial<T>> = Default::default();
+    let mut cross_section: FxHashMap<String, Polynomial<T>> = Default::default();
     for xs_params in params.cross_section_params.values() {
         cross_section.insert(
             xs_params.name.to_owned(),
@@ -367,7 +368,7 @@ pub fn check_cross_sections<T: CustomFloat>(mcdata: &MonteCarloData<T>) {
     }
 
     // compute
-    let mut xc_table: HashMap<String, Vec<XSData<T>>> = Default::default();
+    let mut xc_table: FxHashMap<String, Vec<XSData<T>>> = Default::default();
     // for each material
     matdb.mat.iter().for_each(|material| {
         let mat_name = material.name.to_owned();

--- a/fastiron/src/lib.rs
+++ b/fastiron/src/lib.rs
@@ -103,6 +103,8 @@
 //! [1]: https://github.com/LLNL/Quicksilver
 //! [2]: https://github.com/cea-hpc/fastiron
 
+#![warn(clippy::disallowed_types)]
+
 pub mod constants;
 pub mod data;
 pub mod geometry;

--- a/fastiron/src/montecarlo.rs
+++ b/fastiron/src/montecarlo.rs
@@ -70,7 +70,7 @@ pub struct MonteCarloUnit<T: CustomFloat> {
     pub fast_timer: MCFastTimerContainer,
     /// Weight of the particles at creation in a source zone.
     pub unit_weight: T,
-    /// HashMap used to lazily compute cross-sections.
+    /// Structure used to lazily compute cross-sections.
     pub xs_cache: XSCache<T>,
 }
 

--- a/fastiron/src/parameters.rs
+++ b/fastiron/src/parameters.rs
@@ -4,17 +4,18 @@
 //! simulation. Input reading is located in the [`crate::utils`] module,
 //! while parsing is done here.
 
+use rustc_hash::FxHashMap;
+
 use crate::{
     constants::CustomFloat,
     utils::io_utils::{parse_input_file, Cli, InputError},
 };
-use std::collections::HashMap;
 
-/// Alias for a `<String, String>` [`HashMap`]. See here for detailed
+/// Alias for a `<String, String>` [`FxHashMap`]. See here for detailed
 /// structure of input blocks.
 ///
 /// TODO: Add a breakdown of the input structure
-pub type Block = HashMap<String, String>;
+pub type Block = FxHashMap<String, String>;
 
 /// Enum used to categorize inconsistencies within parameters
 #[derive(Debug, PartialEq)]
@@ -454,9 +455,9 @@ pub struct Parameters<T: CustomFloat> {
     /// List of geometries. See [GeometryParameters] for more.
     pub geometry_params: Vec<GeometryParameters<T>>,
     /// Map of materials. See [MaterialParameters] for more.
-    pub material_params: HashMap<String, MaterialParameters<T>>,
+    pub material_params: FxHashMap<String, MaterialParameters<T>>,
     /// Map of cross sections. See [CrossSectionParameters] for more.
-    pub cross_section_params: HashMap<String, CrossSectionParameters<T>>,
+    pub cross_section_params: FxHashMap<String, CrossSectionParameters<T>>,
 }
 
 impl<T: CustomFloat> Parameters<T> {
@@ -469,8 +470,8 @@ impl<T: CustomFloat> Parameters<T> {
         let mut params = Self {
             simulation_params: SimulationParameters::from_cli(&cli),
             geometry_params: Vec::new(),
-            material_params: HashMap::new(),
-            cross_section_params: HashMap::new(),
+            material_params: FxHashMap::default(),
+            cross_section_params: FxHashMap::default(),
         };
 
         if let Some(filename) = cli.input_file {

--- a/fastiron/tests/misc.rs
+++ b/fastiron/tests/misc.rs
@@ -1,11 +1,12 @@
-use std::{collections::HashMap, hint::black_box};
+use std::hint::black_box;
 
 use num::{Float, ToPrimitive};
+use rustc_hash::FxHashMap;
 
 #[test]
 fn map_behavior() {
-    let mut map: HashMap<usize, usize> = Default::default();
-    let mut complementary_map: HashMap<usize, usize> = Default::default();
+    let mut map: FxHashMap<usize, usize> = Default::default();
+    let mut complementary_map: FxHashMap<usize, usize> = Default::default();
     (0..10).for_each(|jj| {
         (0..5).for_each(|ii| {
             map.insert(jj * 12 + ii, jj * 12 + ii);


### PR DESCRIPTION
Init code is fixed; The speedup is probably around *100. The problem came from the handling of `wet_cells` in the mesh search algorithm. The `Vec::contains()` method is very slow, using a set instead of a vector resulted in the observed speedup.