### PR TITLE
refactor!: handle float type choice at runtime

### DIFF
--- a/fastiron/Cargo.toml
+++ b/fastiron/Cargo.toml
@@ -22,7 +22,6 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 
 # FEATURES
 [features]
-single-precision = []
 
 # BENCH
 

--- a/fastiron/Cargo.toml
+++ b/fastiron/Cargo.toml
@@ -20,9 +20,6 @@ rustc-hash = { version = "2.0.0" }
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
 
-# FEATURES
-[features]
-
 # BENCH
 
 [[bench]]

--- a/fastiron/src/constants.rs
+++ b/fastiron/src/constants.rs
@@ -84,11 +84,8 @@ pub trait CustomFloat: Float + FromPrimitive + OpsFloat + UtilsFloat {
     fn light_speed<T: CustomFloat>() -> T;
 }
 
-#[cfg(feature = "single-precision")]
 impl OpsFloat for f32 {}
-#[cfg(feature = "single-precision")]
 impl UtilsFloat for f32 {}
-#[cfg(feature = "single-precision")]
 impl CustomFloat for f32 {
     /// Threshold value for decimal number when using [f32]. May need adjustment.
     fn huge_float<T: CustomFloat>() -> T {
@@ -118,11 +115,8 @@ impl CustomFloat for f32 {
     }
 }
 
-#[cfg(not(feature = "single-precision"))]
 impl OpsFloat for f64 {}
-#[cfg(not(feature = "single-precision"))]
 impl UtilsFloat for f64 {}
-#[cfg(not(feature = "single-precision"))]
 impl CustomFloat for f64 {
     /// Threshold value for decimal number when using [f64].
     fn huge_float<T: CustomFloat>() -> T {

--- a/fastiron/src/lib.rs
+++ b/fastiron/src/lib.rs
@@ -88,13 +88,6 @@
 //! - [`EnergySpectrum`][crate::data::energy_spectrum::EnergySpectrum]
 //! - [`init::check_cross_sections()`]
 //!
-//! # Features
-//!
-//! Fastiron currently implements one feature:
-//!
-//! - **single-precision** - When enabled, all computations done during the simulation will be done using the
-//!   single-precision float type [`f32`]. By default, every computation is done using [`f64`].
-//!
 //! # Useful Links
 //!
 //! - Fastiron [GitHub repository][2]

--- a/fastiron/src/main.rs
+++ b/fastiron/src/main.rs
@@ -37,7 +37,15 @@ type FloatType = f64;
 fn main() {
     let cli = Cli::parse();
 
-    let params: Parameters<FloatType> = Parameters::get_parameters(cli).unwrap();
+    run::<FloatType>(cli)
+}
+
+//============
+// Main runner
+//============
+
+pub fn run<T: CustomFloat>(cli: Cli) {
+    let params: Parameters<T> = Parameters::get_parameters(cli).unwrap();
     println!("[Simulation Parameters]\n{:#?}", params.simulation_params);
 
     let n_cells_tot =

--- a/fastiron/src/main.rs
+++ b/fastiron/src/main.rs
@@ -20,10 +20,6 @@ use fastiron::utils::input::Cli;
 use fastiron::utils::mc_fast_timer::{self, Section};
 use fastiron::utils::mc_processor_info::ExecPolicy;
 
-//================================
-// Which float type are we using ?
-//================================
-
 //=====
 // Main
 //=====

--- a/fastiron/src/main.rs
+++ b/fastiron/src/main.rs
@@ -24,12 +24,6 @@ use fastiron::utils::mc_processor_info::ExecPolicy;
 // Which float type are we using ?
 //================================
 
-#[cfg(feature = "single-precision")]
-type FloatType = f32;
-
-#[cfg(not(feature = "single-precision"))]
-type FloatType = f64;
-
 //=====
 // Main
 //=====
@@ -37,7 +31,11 @@ type FloatType = f64;
 fn main() {
     let cli = Cli::parse();
 
-    run::<FloatType>(cli)
+    if cli.single_precision {
+        run::<f32>(cli)
+    } else {
+        run::<f64>(cli)
+    }
 }
 
 //============

--- a/fastiron/src/main.rs
+++ b/fastiron/src/main.rs
@@ -32,9 +32,11 @@ fn main() {
     let cli = Cli::parse();
 
     if cli.single_precision {
-        run::<f32>(cli)
+        println!("[INFO] Running simulation using `f32`");
+        run::<f32>(cli);
     } else {
-        run::<f64>(cli)
+        println!("[INFO] Running simulation using `f64`");
+        run::<f64>(cli);
     }
 }
 


### PR DESCRIPTION
This PR removes the `single-precision` feature in favor of a runtime, CLI argument that can be used to run the simulation using either `f32` or `f64`.

The option is `--single-precision`; when present, the simulation will run on `f32`. If absent, the simulation will default to `f64`.

Once this is merged, I will simplify the `CustomFloat` implementation.