### PR TITLE
chore!: update `atomic` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ num = { version = "0.4.3" }
 rand = { version = "0.8.5" }
 tinyvec = { version = "1.6.1" }
 rayon = { version = "1.10.0" }
-atomic = { version = "0.5.3" } # further upgrade == breaking change
+atomic = { version = "0.6.0" }
+bytemuck = { version = "1.16.1" }
 hwlocality = { version = "1.0.0-alpha.5" } 
 libc = { version = "0.2.155" }
 rustc-hash = { version = "2.0.0" }

--- a/fastiron/Cargo.toml
+++ b/fastiron/Cargo.toml
@@ -12,7 +12,8 @@ num = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 tinyvec = { workspace = true }
 rayon = { workspace = true }
-atomic = { workspace = true } # further upgrade == breaking change
+atomic = { workspace = true }
+bytemuck = { workspace = true }
 hwlocality = { workspace = true } 
 libc = { workspace = true }
 rustc-hash = { workspace = true }

--- a/fastiron/src/constants.rs
+++ b/fastiron/src/constants.rs
@@ -62,7 +62,7 @@ pub trait UtilsFloat:
 {
 }
 /// Custom super-trait for floating point number
-pub trait CustomFloat: Float + FromPrimitive + OpsFloat + UtilsFloat {
+pub trait CustomFloat: Float + bytemuck::Pod + FromPrimitive + OpsFloat + UtilsFloat {
     // floating ref
 
     /// Threshold upper-value for decimal number.

--- a/fastiron/src/lib.rs
+++ b/fastiron/src/lib.rs
@@ -97,6 +97,7 @@
 //! [2]: https://github.com/cea-hpc/fastiron
 
 #![warn(clippy::disallowed_types)]
+#![allow(clippy::doc_lazy_continuation)] // TODO: remove & fix lints
 
 pub mod constants;
 pub mod data;


### PR DESCRIPTION
This required adding a `bytemuck::Pod` requirements to the `CustomFloat` trait. Given the [description](https://docs.rs/bytemuck/1.16.1/bytemuck/trait.Pod.html) of the trait, the requirement seems reasonable.